### PR TITLE
improve twig component performances when outputing the dimensions has been disabled

### DIFF
--- a/src/Model/Format.php
+++ b/src/Model/Format.php
@@ -38,4 +38,15 @@ enum Format: string
             self::WEBP => ['webp'],
         };
     }
+
+    public function getMimeType(): string
+    {
+        return match ($this) {
+            self::GIF => 'image/gif',
+            self::HEIF => 'image/heif',
+            self::JPEG => 'image/jpeg',
+            self::PNG => 'image/png',
+            self::WEBP => 'image/webp',
+        };
+    }
 }

--- a/src/Storage/OriginalStorage.php
+++ b/src/Storage/OriginalStorage.php
@@ -244,13 +244,8 @@ class OriginalStorage
             \sprintf('joli_media_mime_type_%s_%s', $this->library->getName(), Resolver::normalizePath($path)),
             function (ItemInterface $item) use ($path): string {
                 $item->expiresAfter(120);
-                $mimeType = $this->getMimeTypeFormContent($this->filesystem->read($path));
 
-                if (null === $mimeType) {
-                    throw new \RuntimeException(\sprintf('Unable to guess the mime type for the file "%s"', $path));
-                }
-
-                return $mimeType;
+                return $this->filesystem->mimeType($this->strategy->getPath($path));
             },
         );
     }

--- a/templates/components/Img.html.twig
+++ b/templates/components/Img.html.twig
@@ -2,6 +2,7 @@
     <twig:joli:Source
         variation="{{ this.webpAlternativeSource }}"
         media="{{ this.media.media }}"
+        skipAutoDimensions="{{ skipAutoDimensions }}"
     />
 {% endif %}
 <img

--- a/templates/components/Picture.html.twig
+++ b/templates/components/Picture.html.twig
@@ -8,11 +8,13 @@
                     mediaAttr="{{ source.media|default(null) }}"
                     sizes="{{ source.sizes|default(null) }}"
                     srcset="{{ source.srcset|default(null) }}"
+                    skipAutoDimensions="{{ skipAutoDimensions }}"
                 />
             {% else %}
                 <twig:joli:Source
                     variation="{{ source }}"
                     media="{{ this.media }}"
+                    skipAutoDimensions="{{ skipAutoDimensions }}"
                 />
             {% endif %}
         {% endfor %}

--- a/tests/src/Twig/Component/ImgTest.php
+++ b/tests/src/Twig/Component/ImgTest.php
@@ -240,6 +240,19 @@ class ImgTest extends WebTestCase
             ],
             '<picture class="picture-class"><source srcset="/media/cache/joli-media-easy-admin/circle-pattern.jpg" type="image/jpeg" width="145" height="109"><source srcset="/media/cache/joli-media-easy-admin-large/circle-pattern.jpg" type="image/jpeg" width="800" height="600"><source srcset="/media/cache/joli-media-easy-admin-webp/circle-pattern.d601f6f2.webp" type="image/webp" width="145" height="109"><img src="/media/cache/joli-media-easy-admin/circle-pattern.jpg" loading="lazy" decoding="async" class="img-class" alt="Alternative text" width="145" height="109"></picture>',
         ];
+        yield 'picture-with-sources-and-skipAutoDimensions' => [
+            Picture::class,
+            [
+                'path' => self::COMPLETELY_STORED_MEDIA,
+                'variation' => 'joli-media-easy-admin',
+                'alt' => 'Alternative text',
+                'picture:class' => 'picture-class',
+                'img:class' => 'img-class',
+                'sources' => ['joli-media-easy-admin', 'joli-media-easy-admin-large'],
+                'skipAutoDimensions' => true,
+            ],
+            '<picture class="picture-class"><source srcset="/media/cache/joli-media-easy-admin/circle-pattern.jpg" type="image/jpeg"><source srcset="/media/cache/joli-media-easy-admin-large/circle-pattern.jpg" type="image/jpeg"><source srcset="/media/cache/joli-media-easy-admin-webp/circle-pattern.d601f6f2.webp" type="image/webp"><img src="/media/cache/joli-media-easy-admin/circle-pattern.jpg" loading="lazy" decoding="async" class="img-class" alt="Alternative text"></picture>',
+        ];
         yield 'partial-picture-with-sources' => [
             Picture::class,
             [
@@ -249,6 +262,19 @@ class ImgTest extends WebTestCase
                 'picture:class' => 'picture-class',
                 'img:class' => 'img-class',
                 'sources' => ['joli-media-easy-admin', 'joli-media-easy-admin-large'],
+            ],
+            '<picture class="picture-class"><source srcset="/media/cache/joli-media-easy-admin/partially-stored-media.jpg"><source srcset="/media/cache/joli-media-easy-admin-large/partially-stored-media.jpg"><source srcset="/media/cache/joli-media-easy-admin-webp/partially-stored-media.b16d66f4.webp"><img src="/media/cache/joli-media-easy-admin/partially-stored-media.jpg" loading="lazy" decoding="async" class="img-class" alt="Alternative text"></picture>',
+        ];
+        yield 'partial-picture-with-sources-and-skipAutoDimensions' => [
+            Picture::class,
+            [
+                'path' => self::PARTIALLY_STORED_MEDIA,
+                'variation' => 'joli-media-easy-admin',
+                'alt' => 'Alternative text',
+                'picture:class' => 'picture-class',
+                'img:class' => 'img-class',
+                'sources' => ['joli-media-easy-admin', 'joli-media-easy-admin-large'],
+                'skipAutoDimensions' => true,
             ],
             '<picture class="picture-class"><source srcset="/media/cache/joli-media-easy-admin/partially-stored-media.jpg"><source srcset="/media/cache/joli-media-easy-admin-large/partially-stored-media.jpg"><source srcset="/media/cache/joli-media-easy-admin-webp/partially-stored-media.b16d66f4.webp"><img src="/media/cache/joli-media-easy-admin/partially-stored-media.jpg" loading="lazy" decoding="async" class="img-class" alt="Alternative text"></picture>',
         ];
@@ -315,7 +341,7 @@ class ImgTest extends WebTestCase
                     ],
                 ]],
             ],
-            '<picture class="picture-class"><source media="(width > 1024px)" sizes="1920px" srcset="/media/cache/joli-media-easy-admin-extra-large/partially-stored-media.jpg 2560w, /media/cache/joli-media-easy-admin-large/partially-stored-media.jpg 1920w"><source media="(width > 1024px)" sizes="1920px" srcset="/media/cache/joli-media-easy-admin-extra-large-webp/partially-stored-media.b16d66f4.webp 2560w, /media/cache/joli-media-easy-admin-large-webp/partially-stored-media.b16d66f4.webp 1920w"><source media="(width >= 768px)" sizes="1024px" srcset="/media/cache/joli-media-easy-admin-large/partially-stored-media.jpg 1600w, /media/cache/joli-media-easy-admin/partially-stored-media.jpg 1024w"><source media="(width >= 768px)" sizes="1024px" srcset="/media/cache/joli-media-easy-admin-large-webp/partially-stored-media.b16d66f4.webp 1600w, /media/cache/joli-media-easy-admin-webp/partially-stored-media.b16d66f4.webp 1024w"><source srcset="/media/cache/joli-media-easy-admin-webp/partially-stored-media.b16d66f4.webp"><img src="/media/cache/joli-media-easy-admin/partially-stored-media.jpg" loading="lazy" decoding="async" class="img-class" alt="Alternative text"></picture>',
+            '<picture class="picture-class"><source media="(width > 1024px)" sizes="1920px" srcset="/media/cache/joli-media-easy-admin-extra-large/partially-stored-media.jpg 2560w, /media/cache/joli-media-easy-admin-large/partially-stored-media.jpg 1920w"><source media="(width > 1024px)" sizes="1920px" srcset="/media/cache/joli-media-easy-admin-extra-large-webp/partially-stored-media.b16d66f4.webp 2560w, /media/cache/joli-media-easy-admin-large-webp/partially-stored-media.b16d66f4.webp 1920w" type="image/webp"><source media="(width >= 768px)" sizes="1024px" srcset="/media/cache/joli-media-easy-admin-large/partially-stored-media.jpg 1600w, /media/cache/joli-media-easy-admin/partially-stored-media.jpg 1024w"><source media="(width >= 768px)" sizes="1024px" srcset="/media/cache/joli-media-easy-admin-large-webp/partially-stored-media.b16d66f4.webp 1600w, /media/cache/joli-media-easy-admin-webp/partially-stored-media.b16d66f4.webp 1024w" type="image/webp"><source srcset="/media/cache/joli-media-easy-admin-webp/partially-stored-media.b16d66f4.webp"><img src="/media/cache/joli-media-easy-admin/partially-stored-media.jpg" loading="lazy" decoding="async" class="img-class" alt="Alternative text"></picture>',
         ];
     }
 


### PR DESCRIPTION
When using `skipAutoDimensions`, we can avoid requesting the media dimensions in order to prevent the bundle from accessing the storage. this improves display performance.