### PR TITLE
allow to customize processor and post-processor options, variation by variation

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -405,7 +405,8 @@ return static function (ContainerConfigurator $container): void {
             '$format' => abstract_arg('format'),
             '$transformerChain' => abstract_arg('transformerChain'),
             '$slugger' => service(SluggerInterface::class),
-            '$postProcessingOptions' => abstract_arg('post_processing_options'),
+            '$processorsConfiguration' => abstract_arg('processors_configuration'),
+            '$postProcessorsConfiguration' => abstract_arg('post_processors_configuration'),
             '$voters' => abstract_arg('joli_media.voters'),
         ])
 

--- a/src/PostProcessor/AbstractPostProcessor.php
+++ b/src/PostProcessor/AbstractPostProcessor.php
@@ -19,6 +19,8 @@ abstract readonly class AbstractPostProcessor extends AbstractProcessCreator imp
     ) {
     }
 
+    abstract public function getName(): string;
+
     abstract public function process(Binary $binary, array $postProcessingOptions = []): Binary;
 
     public function canProcessFormat(string $format): bool

--- a/src/PostProcessor/Gifsicle.php
+++ b/src/PostProcessor/Gifsicle.php
@@ -16,6 +16,11 @@ readonly class Gifsicle extends AbstractPostProcessor implements PostProcessorIn
         'colors' => 256,
     ];
 
+    public function getName(): string
+    {
+        return 'gifsicle';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/PostProcessor/Jpegoptim.php
+++ b/src/PostProcessor/Jpegoptim.php
@@ -16,6 +16,11 @@ readonly class Jpegoptim extends AbstractPostProcessor implements PostProcessorI
         'max_quality' => 80,
     ];
 
+    public function getName(): string
+    {
+        return 'jpegoptim';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/PostProcessor/Mozjpeg.php
+++ b/src/PostProcessor/Mozjpeg.php
@@ -16,6 +16,11 @@ readonly class Mozjpeg extends AbstractPostProcessor implements PostProcessorInt
         'quality' => 80,
     ];
 
+    public function getName(): string
+    {
+        return 'mozjpeg';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/PostProcessor/Oxipng.php
+++ b/src/PostProcessor/Oxipng.php
@@ -16,6 +16,11 @@ readonly class Oxipng extends AbstractPostProcessor implements PostProcessorInte
         'zopfli' => true,
     ];
 
+    public function getName(): string
+    {
+        return 'oxipng';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/PostProcessor/Pngquant.php
+++ b/src/PostProcessor/Pngquant.php
@@ -16,6 +16,11 @@ readonly class Pngquant extends AbstractPostProcessor implements PostProcessorIn
         'speed' => 5,
     ];
 
+    public function getName(): string
+    {
+        return 'pngquant';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/PostProcessor/PostProcessorInterface.php
+++ b/src/PostProcessor/PostProcessorInterface.php
@@ -9,6 +9,8 @@ interface PostProcessorInterface
 {
     public function canProcessFormat(string $format): bool;
 
+    public function getName(): string;
+
     /**
      * @return Format[]
      */

--- a/src/Processor/AbstractProcessor.php
+++ b/src/Processor/AbstractProcessor.php
@@ -20,6 +20,8 @@ abstract readonly class AbstractProcessor extends AbstractProcessCreator impleme
         return \in_array(Format::fromName($outputFormat), $this->getProcessableOutputFormats(), true);
     }
 
+    abstract public function getName(): string;
+
     abstract public function getProcessableInputFormats(): array;
 
     abstract public function getProcessableOutputFormats(): array;

--- a/src/Processor/Cwebp.php
+++ b/src/Processor/Cwebp.php
@@ -40,6 +40,11 @@ readonly class Cwebp extends AbstractProcessor implements ProcessorInterface
     ) {
     }
 
+    public function getName(): string
+    {
+        return 'cwebp';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/Processor/Gif2webp.php
+++ b/src/Processor/Gif2webp.php
@@ -29,6 +29,11 @@ readonly class Gif2webp extends AbstractProcessor implements ProcessorInterface
     ) {
     }
 
+    public function getName(): string
+    {
+        return 'gif2webp';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/Processor/Gifsicle.php
+++ b/src/Processor/Gifsicle.php
@@ -28,6 +28,11 @@ readonly class Gifsicle extends AbstractProcessor implements ProcessorInterface
     ) {
     }
 
+    public function getName(): string
+    {
+        return 'gifsicle';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/Processor/Imagick.php
+++ b/src/Processor/Imagick.php
@@ -34,6 +34,11 @@ readonly class Imagick extends AbstractProcessor implements ProcessorInterface
         return Format::JPEG;
     }
 
+    public function getName(): string
+    {
+        return 'imagick';
+    }
+
     /**
      * @return Format[]
      */

--- a/src/Processor/ProcessorInterface.php
+++ b/src/Processor/ProcessorInterface.php
@@ -12,6 +12,8 @@ interface ProcessorInterface
 
     public function canProcessOutputFormat(string $inputFormat): bool;
 
+    public function getName(): string;
+
     /**
      * @return Format[]
      */

--- a/src/Transformation/Transformation.php
+++ b/src/Transformation/Transformation.php
@@ -135,6 +135,22 @@ class Transformation
         return $outputFormats;
     }
 
+    /**
+     * @return array<string, string[]>
+     */
+    public function getPostProcessorOptions(string $postProcessorName): array
+    {
+        return $this->variation->getPostProcessorConfiguration($postProcessorName);
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getProcessorOptions(string $processorName): array
+    {
+        return $this->variation->getProcessorConfiguration($processorName);
+    }
+
     public function getVariationName(): string
     {
         return $this->variation->getName();

--- a/src/Transformation/TransformationProcessor.php
+++ b/src/Transformation/TransformationProcessor.php
@@ -30,7 +30,7 @@ readonly class TransformationProcessor
         $transformation->applyTransformers();
         $binary = $this->runTransformation($transformation);
 
-        return $this->runPostProcessors($binary);
+        return $this->runPostProcessors($transformation, $binary);
     }
 
     private function runTransformation(Transformation $transformation): Binary
@@ -45,7 +45,7 @@ readonly class TransformationProcessor
                     return $processor->process(
                         $transformation->getBinary(),
                         $transformation,
-                        [],
+                        $transformation->getProcessorOptions($processor->getName()),
                         $outputFormat,
                     );
                 } catch (\Exception $e) {
@@ -64,10 +64,13 @@ readonly class TransformationProcessor
         throw new \RuntimeException('No processor worked for this variation');
     }
 
-    private function runPostProcessors(Binary $binary): Binary
+    private function runPostProcessors(Transformation $transformation, Binary $binary): Binary
     {
         foreach ($this->postProcessorContainer->getPostProcessors($binary->getFormat()) as $postProcessor) {
-            $binary = $postProcessor->process($binary, []);
+            $binary = $postProcessor->process(
+                $binary,
+                $transformation->getPostProcessorOptions($postProcessor->getName()),
+            );
         }
 
         return $binary;

--- a/src/Variation/Variation.php
+++ b/src/Variation/Variation.php
@@ -15,8 +15,9 @@ use Symfony\Component\String\Slugger\SluggerInterface;
 class Variation
 {
     /**
-     * @param array<string, string[]> $postProcessingOptions
-     * @param VoterInterface[]        $voters
+     * @param array<string, array<string, string[]>> $processorsConfiguration
+     * @param array<string, array<string, string[]>> $postProcessorsConfiguration
+     * @param VoterInterface[]                       $voters
      */
     public function __construct(
         private readonly string $name,
@@ -25,7 +26,8 @@ class Variation
         private readonly SluggerInterface $slugger = new AsciiSlugger(),
         private readonly ServiceLocator $globalPreProcessors = new ServiceLocator([]),
         private readonly ServiceLocator $preProcessors = new ServiceLocator([]),
-        private readonly array $postProcessingOptions = [],
+        private readonly array $processorsConfiguration = [],
+        private readonly array $postProcessorsConfiguration = [],
         private readonly array $voters = [],
         private ?self $webpAlternativeVariation = null,
     ) {
@@ -51,7 +53,8 @@ class Variation
             $this->slugger,
             $this->globalPreProcessors,
             $this->preProcessors,
-            $this->postProcessingOptions,
+            $this->processorsConfiguration,
+            $this->postProcessorsConfiguration,
             $this->voters,
             $this->webpAlternativeVariation,
         );
@@ -99,9 +102,9 @@ class Variation
     /**
      * @return array<string, string[]>
      */
-    public function getPostProcessingOptions(): array
+    public function getPostProcessorConfiguration(string $postProcessorName): array
     {
-        return $this->postProcessingOptions;
+        return $this->postProcessorsConfiguration[$postProcessorName] ?? [];
     }
 
     /**
@@ -116,6 +119,14 @@ class Variation
         foreach ($this->preProcessors as $id => $service) {
             yield $id => $service;
         }
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getProcessorConfiguration(string $processorName): array
+    {
+        return $this->processorsConfiguration[$processorName] ?? [];
     }
 
     public function getSlug(): string

--- a/tests/src/Variation/VariationTest.php
+++ b/tests/src/Variation/VariationTest.php
@@ -47,7 +47,7 @@ class VariationTest extends BaseTestCase
             preProcessors: new ServiceLocator([
                 TestPreProcessor::class => fn (): PreProcessorInterface => $this->preProcessor,
             ]),
-            postProcessingOptions: ['quality' => ['80']],
+            postProcessorsConfiguration: ['jpegoptim' => ['options' => ['max_quality' => '80']]],
             voters: [
                 new FormatVoter('jpg'),
                 new MimeTypeVoter('image/jpeg'),
@@ -74,7 +74,7 @@ class VariationTest extends BaseTestCase
 
     public function testGetPostProcessingOptions(): void
     {
-        self::assertEquals(['quality' => ['80']], $this->variation->getPostProcessingOptions());
+        self::assertEquals(['options' => ['max_quality' => '80']], $this->variation->getPostProcessorConfiguration('jpegoptim'));
     }
 
     public function testGetPreProcessors(): void
@@ -91,7 +91,7 @@ class VariationTest extends BaseTestCase
             preProcessors: new ServiceLocator([
                 TestPreProcessor::class => fn (): PreProcessorInterface => $this->preProcessor,
             ]),
-            postProcessingOptions: ['quality' => ['80']],
+            postProcessorsConfiguration: ['jpegoptim' => ['options' => ['max_quality' => '80']]],
             voters: [
                 new FormatVoter('jpg'),
                 new MimeTypeVoter('image/jpeg'),
@@ -142,7 +142,7 @@ class VariationTest extends BaseTestCase
         self::assertEquals('test_variation', $clonedVariation->getName());
         self::assertEquals(Format::PNG, $clonedVariation->getFormat());
         self::assertSame($this->transformerChain, $clonedVariation->getTransformerChain());
-        self::assertEquals(['quality' => ['80']], $clonedVariation->getPostProcessingOptions());
+        self::assertEquals(['options' => ['max_quality' => '80']], $clonedVariation->getPostProcessorConfiguration('jpegoptim'));
         self::assertSame($this->preProcessor, $clonedVariation->getPreProcessors()->current());
     }
 


### PR DESCRIPTION
In certain situations, you may want to override the default processor or postprocessor configuration for a specific variation only. For example, the default quality for transformations could be "70", except for a specific high quality variation that you need to use 95 as the quality score.

This PR allows to override processor and postProcessor options at the variation definition level.

Missing:
 * [ ] documentation