### PR TITLE
Only list variations that can be applied to the media

### DIFF
--- a/src/Bridge/EasyAdmin/src/Controller/MediaAdminController.php
+++ b/src/Bridge/EasyAdmin/src/Controller/MediaAdminController.php
@@ -481,10 +481,14 @@ class MediaAdminController extends AbstractController
             $variations = $this->getLibrary()->getVariationContainer()->list();
 
             foreach ($variations as $variation) {
-                if (
-                    $this->config->isVisible('show_variations_list_admin_variations')
-                    || !str_starts_with($variation->getName(), 'joli-media-easy-admin') && !str_starts_with($variation->getName(), 'joli-media-sonata-admin')
+                if (!$this->config->isVisible('show_variations_list_admin_variations')
+                    && (str_starts_with($variation->getName(), 'joli-media-easy-admin')
+                        || str_starts_with($variation->getName(), 'joli-media-sonata-admin'))
                 ) {
+                    continue;
+                }
+
+                if ($variation->canBeAppliedTo($media)) {
                     $media->createVariation($variation);
                 }
             }

--- a/src/Bridge/SonataAdmin/src/Controller/MediaAdminController.php
+++ b/src/Bridge/SonataAdmin/src/Controller/MediaAdminController.php
@@ -440,13 +440,14 @@ class MediaAdminController extends AbstractController
             $variations = $this->getLibrary()->getVariationContainer()->list();
 
             foreach ($variations as $variation) {
-                if (
-                    (
-                        $this->config->isVisible('show_variations_list_admin_variations')
-                        || !str_starts_with($variation->getName(), 'joli-media-easy-admin') && !str_starts_with($variation->getName(), 'joli-media-sonata-admin')
-                    )
-                    && $variation->canBeAppliedTo($media)
+                if (!$this->config->isVisible('show_variations_list_admin_variations')
+                    && (str_starts_with($variation->getName(), 'joli-media-easy-admin')
+                        || str_starts_with($variation->getName(), 'joli-media-sonata-admin'))
                 ) {
+                    continue;
+                }
+
+                if ($variation->canBeAppliedTo($media)) {
                     $media->createVariation($variation);
                 }
             }


### PR DESCRIPTION
In the media show view, prevents to list variations that cannot be applied to the media because of voters.