### PR TITLE
Remove a media variations prior to storing it again

### DIFF
--- a/src/Storage/OriginalStorage.php
+++ b/src/Storage/OriginalStorage.php
@@ -100,12 +100,12 @@ class OriginalStorage
             $this->dispatcher->dispatch($event, MediaEvents::PRE_CREATE_MEDIA);
         }
 
+        $this->getLibrary()->deleteAllVariations($path);
         $this->filesystem->write($path, $binary->getContent(), [
             Config::OPTION_VISIBILITY => 'public',
             Config::OPTION_DIRECTORY_VISIBILITY => 'public',
         ]);
         $this->mediaPropertyAccessor->clearCache($path);
-        $this->getLibrary()->deleteAllVariations($path);
         $media = new Media($path, $this, $binary);
 
         if ($this->dispatcher->hasListeners(MediaEvents::POST_CREATE_MEDIA)) {


### PR DESCRIPTION
Remove the variations for a media, if they existed, before this media is stored itself. Else, if the variation are stored in the same path os the original (for example a dynamically computed media for which we do not want to store non-optimized original versions), the newly created original would be removed when removing the variations.