### PR TITLE
Do not throw an exception when a variation cannot be generated using the controller because of voters

### DIFF
--- a/src/Controller/MediaController.php
+++ b/src/Controller/MediaController.php
@@ -3,7 +3,6 @@
 namespace JoliCode\MediaBundle\Controller;
 
 use JoliCode\MediaBundle\Conversion\Converter;
-use JoliCode\MediaBundle\Exception\VariationNotFoundException;
 use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Resolver\Resolver;
 use Psr\Log\LoggerInterface;
@@ -58,8 +57,8 @@ class MediaController extends AbstractController
 
             $this->converter->convertMediaVariation($mediaVariation, false);
             $binary = $mediaVariation->getBinary();
-        } catch (\InvalidArgumentException|VariationNotFoundException $e) {
-            throw $this->createNotFoundException('File not found', $e);
+        } catch (\Exception $exception) {
+            throw $this->createNotFoundException('File not found', $exception);
         }
 
         return new Response($binary->getContent(), Response::HTTP_OK, [

--- a/src/Routing/RouteChecker.php
+++ b/src/Routing/RouteChecker.php
@@ -36,7 +36,13 @@ readonly class RouteChecker
                 return false;
             }
 
-            return $this->resolver->resolveMediaVariation($slug, $variation, $library) instanceof MediaVariation;
+            try {
+                $mediaVariation = $this->resolver->resolveMediaVariation($slug, $variation, $library);
+            } catch (\Exception) {
+                return false;
+            }
+
+            return $mediaVariation instanceof MediaVariation;
         }
 
         try {


### PR DESCRIPTION
Do not throw an exception when calling the variation controller to generate a variation for a media that voters prevent.
If a variation cannot be dynamically generated, simply return a 404 Not Found response.