### PR TITLE
Fix Doctrine dependency

### DIFF
--- a/src/DependencyInjection/Compiler/DoctrinePass.php
+++ b/src/DependencyInjection/Compiler/DoctrinePass.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\MediaBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class DoctrinePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+
+        if (isset($bundles['DoctrineBundle'])) {
+            return;
+        }
+
+        $container->removeDefinition('joli_media.cache_warmer.media_entity_metadata');
+        $container->removeDefinition('joli_media.event_listener.folder_delete');
+        $container->removeDefinition('joli_media.event_listener.folder_move');
+        $container->removeDefinition('joli_media.event_listener.media_delete');
+        $container->removeDefinition('joli_media.event_listener.media_move');
+    }
+}

--- a/src/JoliMediaBundle.php
+++ b/src/JoliMediaBundle.php
@@ -8,6 +8,7 @@ use Imagine\Gd\Imagine as GdImagine;
 use Imagine\Gmagick\Imagine as GmagickImagine;
 use Imagine\Imagick\Imagine as ImagickImagine;
 use JoliCode\MediaBundle\DependencyInjection\Compiler\CollectorPass;
+use JoliCode\MediaBundle\DependencyInjection\Compiler\DoctrinePass;
 use JoliCode\MediaBundle\Doctrine\Type\MediaLongType;
 use JoliCode\MediaBundle\Doctrine\Type\MediaType;
 use JoliCode\MediaBundle\Doctrine\Types;
@@ -31,6 +32,10 @@ class JoliMediaBundle extends AbstractBundle
 {
     public function boot(): void
     {
+        if (!class_exists(\Doctrine\DBAL\Types\StringType::class)) {
+            return;
+        }
+
         // doctrine media type
         $resolverInitializer = fn (): ?object => $this->container->get('joli_media.resolver');
         MediaType::$resolverInitializer = $resolverInitializer;
@@ -42,6 +47,7 @@ class JoliMediaBundle extends AbstractBundle
         parent::build($container);
 
         $container->addCompilerPass(new CollectorPass());
+        $container->addCompilerPass(new DoctrinePass());
     }
 
     public function configure(DefinitionConfigurator $definition): void


### PR DESCRIPTION
This PR provides a proposed fix for #59.

- Removes Doctrine-dependent services using a compiler pass
- Adds conditional resolver initialization for MediaType