### PR TITLE
Fix Symfony mime dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "symfony/http-foundation": "^7.0 || ^8.0",
         "symfony/http-kernel": "^7.0 || ^8.0",
         "symfony/intl": "^7.0 || ^8.0",
+        "symfony/mime": "^7.0 || ^8.0",
         "symfony/process": "^7.0 || ^8.0",
         "symfony/routing": "^7.0 || ^8.0",
         "symfony/runtime": "^7.0 || ^8.0",


### PR DESCRIPTION
The service `joli_media.mime_type_guesser` depends on classes from `symfony/mime`.
Since this service is used internally by other services in the bundle, `symfony/mime` must be present to ensure proper initialization and avoid runtime errors.