### PR TITLE
auto register the easyadmin media field to work with the media custom doctrine types

### DIFF
--- a/src/Bridge/EasyAdmin/src/JoliMediaEasyAdminBundle.php
+++ b/src/Bridge/EasyAdmin/src/JoliMediaEasyAdminBundle.php
@@ -2,6 +2,9 @@
 
 namespace JoliCode\MediaBundle\Bridge\EasyAdmin;
 
+use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
+use JoliCode\MediaBundle\Bridge\EasyAdmin\Field\MediaChoiceField;
+use JoliCode\MediaBundle\Doctrine\Types;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -9,6 +12,16 @@ use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
 class JoliMediaEasyAdminBundle extends AbstractBundle
 {
+    public function boot(): void
+    {
+        $reflection = new \ReflectionClass(FieldFactory::class);;
+        $doctrineTypes = array_merge($reflection->getStaticPropertyValue('doctrineTypeToFieldFqcn'), [
+            Types::MEDIA => MediaChoiceField::class,
+            Types::MEDIA_LONG => MediaChoiceField::class,
+        ]);
+        $reflection->setStaticPropertyValue('doctrineTypeToFieldFqcn', $doctrineTypes);
+    }
+
     public function configure(DefinitionConfigurator $definition): void
     {
         $definition->rootNode()


### PR DESCRIPTION
fix #77

 * add a media field to a doctrine entity
 * create a new easyadmin crud using `bin/console make:admin:crud`
 * browse the index of this crud controller
 * the `media` field uses the media field type