### PR TITLE
Add getFilesystem method to CacheStorage

### DIFF
--- a/src/Storage/CacheStorage.php
+++ b/src/Storage/CacheStorage.php
@@ -88,6 +88,11 @@ class CacheStorage
         return $this->library;
     }
 
+    public function getFilesystem(): Filesystem
+    {
+        return $this->filesystem;
+    }
+
     public function getMediaVariationPropertyAccessor(): MediaVariationPropertyAccessor
     {
         return $this->mediaVariationPropertyAccessor;


### PR DESCRIPTION
Just like the OriginalStorage exposes storage. Without this change it does not seem possible to generate temporaryUrls for S3 buckets.

Relates to #75 , so adding temporary url generation and not exposing filesystem is fine by me as well.

Workaround for now; wire the same Flysystem filesystem to my own action until this PR becomes available or temporary url generation is integrated.