### PR TITLE
Make MediaEntityMetadataWarmer non-optional

### DIFF
--- a/src/Cache/MediaEntityMetadataWarmer.php
+++ b/src/Cache/MediaEntityMetadataWarmer.php
@@ -24,7 +24,7 @@ readonly class MediaEntityMetadataWarmer implements CacheWarmerInterface
 
     public function isOptional(): bool
     {
-        return false;
+        return true;
     }
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array


### PR DESCRIPTION
I ran into am issue where my app started to throw errors during cache warming in production mode.

What happens is the following:

`JoliCode\MediaBundle\Cache\MediaEntityMetadataWarmer` gets scheduled to warm up *before* `Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer`.

During this warm-up phase the `MediaEntityMetadataWarmer` calls `$objectManager->getMetadataFactory()->getAllMetadata()`, which effectively loads all entity metadata.

A later point in time `DoctrineMetadataCacheWarmer` starts warming the cache, notices that the entity metadata has already been loaded and throws an Exception stating this should not be done.
 

I'm not an expert at Symfony's internals by any means, but from what I've been able to reconstruct it seems to me that Symfony orders CacheWarmers both by priority and whether or not they are optional. As a result what appears to happen is the following:

1. Symfony cycles through the CacheWarmers by priority (highest priority first), but *only* executes the non-optional warmers (which includes `MediaEntityMetadataWarmer`).
2. Only after the non-optional warmers have executed does Symfony cycle through again, this time executing *only* the optional ones (which includes `DoctrineMetadataCacheWarmer`).

So while `DoctrineMetadataCacheWarmer` *does* have the highest priority, it still gets executed later, because it's part of the 2nd optional cycle, whereas `MediaEntityMetadataWarmer` is part of the preceding non-optional cycle.


The easy fix appears to be to make `MediaEntityMetadataWarmer` optional as well. At first glance it does not appear to cause problems in my application, but since I'm not familiar with this part of Symfony at all I could be missing something important.

Either way, here's a pull request with the easy fix. If I'm missing something important, please let me know.