### PR TITLE
fix(media): restore Media state on unserialize from Doctrine cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feature - The EasyAdmin media library is now browsed through pretty URLs whenever the application uses EasyAdmin pretty URLs - see the [EasyAdmin bridge documentation](doc/bridges/easy-admin.rst)
 - improvement - The admin bridges JavaScript no longer relies on UI classes to find or toggle elements: behavior is hooked on `data-component` attributes, and state on `data-active`, `data-empty`, `data-copied` or the `hidden` attribute
 - improvement - Allow `symfony/ux-twig-component` 3.x in addition to 2.x
+- fix - `Media` objects are now correctly restored when unserialized, for instance when they are read from the Doctrine second level cache
 
 ## [0.8.0] - 2026-07-30
 

--- a/src/Exception/InvalidSerializedMediaException.php
+++ b/src/Exception/InvalidSerializedMediaException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JoliCode\MediaBundle\Exception;
+
+class InvalidSerializedMediaException extends \UnexpectedValueException
+{
+}

--- a/src/JoliMediaBundle.php
+++ b/src/JoliMediaBundle.php
@@ -15,7 +15,6 @@ use JoliCode\MediaBundle\Doctrine\Type\MediaType;
 use JoliCode\MediaBundle\Doctrine\Types;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
-use JoliCode\MediaBundle\Storage\OriginalStorage;
 use JoliCode\MediaBundle\PreProcessor\HeifPreProcessor;
 use JoliCode\MediaBundle\Processor\Imagine;
 use JoliCode\MediaBundle\Transformer\Resize\Mode;
@@ -36,13 +35,13 @@ class JoliMediaBundle extends AbstractBundle
 {
     public function boot(): void
     {
+        // media unserialization does not depend on Doctrine: this must be set
+        // before the Doctrine check below
+        Media::$libraryContainerInitializer = fn (): ?object => $this->container->get('joli_media.library_container');
+
         if (!class_exists(StringType::class)) {
             return;
         }
-
-        $libraryContainerInitializer = fn (): ?object => $this->container->get('joli_media.library_container');
-        Media::$libraryContainerInitializer = $libraryContainerInitializer;
-        OriginalStorage::$libraryContainerInitializer = $libraryContainerInitializer;
 
         // doctrine media type
         $resolverInitializer = fn (): ?object => $this->container->get('joli_media.resolver');

--- a/src/JoliMediaBundle.php
+++ b/src/JoliMediaBundle.php
@@ -14,6 +14,7 @@ use JoliCode\MediaBundle\Doctrine\Type\MediaLongType;
 use JoliCode\MediaBundle\Doctrine\Type\MediaType;
 use JoliCode\MediaBundle\Doctrine\Types;
 use JoliCode\MediaBundle\Model\Format;
+use JoliCode\MediaBundle\Model\Media;
 use JoliCode\MediaBundle\PreProcessor\HeifPreProcessor;
 use JoliCode\MediaBundle\Processor\Imagine;
 use JoliCode\MediaBundle\Transformer\Resize\Mode;
@@ -40,6 +41,7 @@ class JoliMediaBundle extends AbstractBundle
 
         // doctrine media type
         $resolverInitializer = fn (): ?object => $this->container->get('joli_media.resolver');
+        Media::$resolverInitializer = $resolverInitializer;
         MediaType::$resolverInitializer = $resolverInitializer;
         MediaLongType::$resolverInitializer = $resolverInitializer;
     }

--- a/src/JoliMediaBundle.php
+++ b/src/JoliMediaBundle.php
@@ -15,6 +15,7 @@ use JoliCode\MediaBundle\Doctrine\Type\MediaType;
 use JoliCode\MediaBundle\Doctrine\Types;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
+use JoliCode\MediaBundle\Storage\OriginalStorage;
 use JoliCode\MediaBundle\PreProcessor\HeifPreProcessor;
 use JoliCode\MediaBundle\Processor\Imagine;
 use JoliCode\MediaBundle\Transformer\Resize\Mode;
@@ -39,9 +40,12 @@ class JoliMediaBundle extends AbstractBundle
             return;
         }
 
+        $libraryContainerInitializer = fn (): ?object => $this->container->get('joli_media.library_container');
+        Media::$libraryContainerInitializer = $libraryContainerInitializer;
+        OriginalStorage::$libraryContainerInitializer = $libraryContainerInitializer;
+
         // doctrine media type
         $resolverInitializer = fn (): ?object => $this->container->get('joli_media.resolver');
-        Media::$resolverInitializer = $resolverInitializer;
         MediaType::$resolverInitializer = $resolverInitializer;
         MediaLongType::$resolverInitializer = $resolverInitializer;
     }

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -41,6 +41,9 @@ class Media implements StorableInterface
         ];
     }
 
+    /**
+     * @param array<int|string, mixed> $data
+     */
     public function __unserialize(array $data): void
     {
         $path = $data['path'] ?? $data[0] ?? null;

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -3,13 +3,22 @@
 namespace JoliCode\MediaBundle\Model;
 
 use JoliCode\MediaBundle\Binary\Binary;
+use JoliCode\MediaBundle\Exception\MediaNotFoundException;
 use JoliCode\MediaBundle\Library\Library;
+use JoliCode\MediaBundle\Resolver\Resolver;
 use JoliCode\MediaBundle\Storage\OriginalStorage;
 use JoliCode\MediaBundle\Variation\Variation;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class Media implements StorableInterface
 {
+    /**
+     * @var callable(): Resolver|null
+     */
+    public static $resolverInitializer;
+
+    private static Resolver $resolver;
+
     /**
      * @var array<string, MediaVariation>
      */
@@ -26,7 +35,32 @@ class Media implements StorableInterface
 
     public function __serialize(): array
     {
-        return [$this->path, $this->storage->getLibrary()->getName()];
+        return [
+            'path' => $this->path,
+            'library' => $this->storage->getLibrary()->getName(),
+        ];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $path = $data['path'] ?? $data[0] ?? null;
+        $libraryName = $data['library'] ?? $data[1] ?? null;
+
+        if (!\is_string($path) || !\is_string($libraryName)) {
+            throw new \UnexpectedValueException('Invalid serialized media payload.');
+        }
+
+        try {
+            $resolvedMedia = self::getResolver()->resolveMedia($path, $libraryName);
+        } catch (MediaNotFoundException) {
+            $resolvedMedia = self::getResolver()->createUnresolvedMedia($path, $libraryName);
+        }
+
+        $this->path = $resolvedMedia->path;
+        $this->storage = $resolvedMedia->storage;
+        $this->binary = null;
+        $this->stored = null;
+        $this->variations = [];
     }
 
     public function addVariation(MediaVariation $variation): void
@@ -213,5 +247,18 @@ class Media implements StorableInterface
 
         $this->storage->createMediaFromBinary($this->path, $this->binary);
         $this->stored = true;
+    }
+
+    private static function getResolver(): Resolver
+    {
+        if (!isset(self::$resolver)) {
+            if (!isset(self::$resolverInitializer)) {
+                throw new \LogicException('Resolver Initializer is not set.');
+            }
+
+            self::$resolver = (self::$resolverInitializer)();
+        }
+
+        return self::$resolver;
     }
 }

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -51,9 +51,9 @@ class Media implements StorableInterface
         }
 
         try {
-            $resolvedMedia = self::getResolver()->resolveMedia($path, $libraryName);
+            $resolvedMedia = $this->getResolver()->resolveMedia($path, $libraryName);
         } catch (MediaNotFoundException) {
-            $resolvedMedia = self::getResolver()->createUnresolvedMedia($path, $libraryName);
+            $resolvedMedia = $this->getResolver()->createUnresolvedMedia($path, $libraryName);
         }
 
         $this->path = $resolvedMedia->path;
@@ -249,7 +249,7 @@ class Media implements StorableInterface
         $this->stored = true;
     }
 
-    private static function getResolver(): Resolver
+    private function getResolver(): Resolver
     {
         if (!isset(self::$resolver)) {
             if (!isset(self::$resolverInitializer)) {

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -3,6 +3,7 @@
 namespace JoliCode\MediaBundle\Model;
 
 use JoliCode\MediaBundle\Binary\Binary;
+use JoliCode\MediaBundle\Exception\InvalidSerializedMediaException;
 use JoliCode\MediaBundle\Library\Library;
 use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Storage\OriginalStorage;
@@ -15,8 +16,6 @@ class Media implements StorableInterface
      * @var callable(): LibraryContainer|null
      */
     public static $libraryContainerInitializer;
-
-    private static LibraryContainer $libraryContainer;
 
     /**
      * @var array<string, MediaVariation>
@@ -36,7 +35,7 @@ class Media implements StorableInterface
     {
         return [
             'path' => $this->path,
-            'storage' => $this->storage,
+            'library' => $this->storage->getLibrary()->getName(),
         ];
     }
 
@@ -45,26 +44,16 @@ class Media implements StorableInterface
      */
     public function __unserialize(array $data): void
     {
-        if (isset($data['path'], $data['storage']) && \is_string($data['path']) && $data['storage'] instanceof OriginalStorage) {
-            // Restore the exact cached path and re-attach the live storage service.
-            // Prefer the container instance over the temporary unserialize handle.
-            $this->path = $data['path'];
-            $this->storage = $data['storage']->getLibrary()->getOriginalStorage();
-        } else {
-            // Backward compatibility with legacy payloads:
-            // - ['path' => ..., 'library' => ...]
-            // - [0 => path, 1 => library]
-            $path = $data['path'] ?? $data[0] ?? null;
-            $libraryName = $data['library'] ?? $data[1] ?? null;
+        // Legacy payloads are indexed ([0 => path, 1 => library name]).
+        $path = $data['path'] ?? $data[0] ?? null;
+        $libraryName = $data['library'] ?? $data[1] ?? null;
 
-            if (!\is_string($path) || !\is_string($libraryName)) {
-                throw new \UnexpectedValueException('Invalid serialized media payload.');
-            }
-
-            $this->path = $path;
-            $this->storage = self::getLibraryContainer()->get($libraryName)->getOriginalStorage();
+        if (!\is_string($path) || !\is_string($libraryName)) {
+            throw new InvalidSerializedMediaException('Invalid serialized media payload.');
         }
 
+        $this->path = $path;
+        $this->storage = self::getLibraryContainer()->get($libraryName)->getOriginalStorage();
         $this->binary = null;
         $this->stored = null;
         $this->variations = [];
@@ -258,14 +247,11 @@ class Media implements StorableInterface
 
     private static function getLibraryContainer(): LibraryContainer
     {
-        if (!isset(self::$libraryContainer)) {
-            if (!isset(self::$libraryContainerInitializer)) {
-                throw new \LogicException('Library container initializer is not set.');
-            }
-
-            self::$libraryContainer = (self::$libraryContainerInitializer)();
+        if (!isset(self::$libraryContainerInitializer)) {
+            throw new \LogicException('Library container initializer is not set.');
         }
 
-        return self::$libraryContainer;
+        // not memoized on purpose
+        return (self::$libraryContainerInitializer)();
     }
 }

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -3,9 +3,8 @@
 namespace JoliCode\MediaBundle\Model;
 
 use JoliCode\MediaBundle\Binary\Binary;
-use JoliCode\MediaBundle\Exception\MediaNotFoundException;
 use JoliCode\MediaBundle\Library\Library;
-use JoliCode\MediaBundle\Resolver\Resolver;
+use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Storage\OriginalStorage;
 use JoliCode\MediaBundle\Variation\Variation;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -13,11 +12,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class Media implements StorableInterface
 {
     /**
-     * @var callable(): Resolver|null
+     * @var callable(): LibraryContainer|null
      */
-    public static $resolverInitializer;
+    public static $libraryContainerInitializer;
 
-    private static Resolver $resolver;
+    private static LibraryContainer $libraryContainer;
 
     /**
      * @var array<string, MediaVariation>
@@ -37,7 +36,7 @@ class Media implements StorableInterface
     {
         return [
             'path' => $this->path,
-            'library' => $this->storage->getLibrary()->getName(),
+            'storage' => $this->storage,
         ];
     }
 
@@ -46,21 +45,26 @@ class Media implements StorableInterface
      */
     public function __unserialize(array $data): void
     {
-        $path = $data['path'] ?? $data[0] ?? null;
-        $libraryName = $data['library'] ?? $data[1] ?? null;
+        if (isset($data['path'], $data['storage']) && \is_string($data['path']) && $data['storage'] instanceof OriginalStorage) {
+            // Restore the exact cached path and re-attach the live storage service.
+            // Prefer the container instance over the temporary unserialize handle.
+            $this->path = $data['path'];
+            $this->storage = $data['storage']->getLibrary()->getOriginalStorage();
+        } else {
+            // Backward compatibility with legacy payloads:
+            // - ['path' => ..., 'library' => ...]
+            // - [0 => path, 1 => library]
+            $path = $data['path'] ?? $data[0] ?? null;
+            $libraryName = $data['library'] ?? $data[1] ?? null;
 
-        if (!\is_string($path) || !\is_string($libraryName)) {
-            throw new \UnexpectedValueException('Invalid serialized media payload.');
+            if (!\is_string($path) || !\is_string($libraryName)) {
+                throw new \UnexpectedValueException('Invalid serialized media payload.');
+            }
+
+            $this->path = $path;
+            $this->storage = self::getLibraryContainer()->get($libraryName)->getOriginalStorage();
         }
 
-        try {
-            $resolvedMedia = $this->getResolver()->resolveMedia($path, $libraryName);
-        } catch (MediaNotFoundException) {
-            $resolvedMedia = $this->getResolver()->createUnresolvedMedia($path, $libraryName);
-        }
-
-        $this->path = $resolvedMedia->path;
-        $this->storage = $resolvedMedia->storage;
         $this->binary = null;
         $this->stored = null;
         $this->variations = [];
@@ -252,16 +256,16 @@ class Media implements StorableInterface
         $this->stored = true;
     }
 
-    private function getResolver(): Resolver
+    private static function getLibraryContainer(): LibraryContainer
     {
-        if (!isset(self::$resolver)) {
-            if (!isset(self::$resolverInitializer)) {
-                throw new \LogicException('Resolver Initializer is not set.');
+        if (!isset(self::$libraryContainer)) {
+            if (!isset(self::$libraryContainerInitializer)) {
+                throw new \LogicException('Library container initializer is not set.');
             }
 
-            self::$resolver = (self::$resolverInitializer)();
+            self::$libraryContainer = (self::$libraryContainerInitializer)();
         }
 
-        return self::$resolver;
+        return self::$libraryContainer;
     }
 }

--- a/src/Storage/OriginalStorage.php
+++ b/src/Storage/OriginalStorage.php
@@ -50,10 +50,7 @@ class OriginalStorage
 
     public function __serialize(): array
     {
-        return [
-            'urlPath',
-            'strategy',
-        ];
+        throw new \LogicException(\sprintf('A "%s" is a service and must not be serialized. Serialize the media it holds instead.', self::class));
     }
 
     public function createDirectory(string $path): void

--- a/src/Storage/OriginalStorage.php
+++ b/src/Storage/OriginalStorage.php
@@ -21,7 +21,6 @@ use JoliCode\MediaBundle\Event\PreResolveMediaEvent;
 use JoliCode\MediaBundle\Exception\ForbiddenPathException;
 use JoliCode\MediaBundle\Exception\PathAlreadyExistsException;
 use JoliCode\MediaBundle\Library\Library;
-use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Model\Media;
 use JoliCode\MediaBundle\Resolver\Resolver;
 use JoliCode\MediaBundle\Storage\Strategy\StorageStrategyInterface;
@@ -34,13 +33,6 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class OriginalStorage
 {
-    /**
-     * @var callable(): LibraryContainer|null
-     */
-    public static $libraryContainerInitializer;
-
-    private static LibraryContainer $libraryContainer;
-
     private Library $library;
 
     public function __construct(
@@ -59,23 +51,9 @@ class OriginalStorage
     public function __serialize(): array
     {
         return [
-            'library' => $this->library->getName(),
+            'urlPath',
+            'strategy',
         ];
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    public function __unserialize(array $data): void
-    {
-        $libraryName = $data['library'] ?? null;
-
-        if (!\is_string($libraryName)) {
-            throw new \UnexpectedValueException('Invalid serialized original storage payload.');
-        }
-
-        // Handle only: Media re-attaches the live storage from the library.
-        $this->library = self::getLibraryContainer()->get($libraryName);
     }
 
     public function createDirectory(string $path): void
@@ -561,19 +539,6 @@ class OriginalStorage
     public function setLibrary(Library $library): void
     {
         $this->library = $library;
-    }
-
-    private static function getLibraryContainer(): LibraryContainer
-    {
-        if (!isset(self::$libraryContainer)) {
-            if (!isset(self::$libraryContainerInitializer)) {
-                throw new \LogicException('Library container initializer is not set.');
-            }
-
-            self::$libraryContainer = (self::$libraryContainerInitializer)();
-        }
-
-        return self::$libraryContainer;
     }
 
     private function getRouteName(): string

--- a/src/Storage/OriginalStorage.php
+++ b/src/Storage/OriginalStorage.php
@@ -21,6 +21,7 @@ use JoliCode\MediaBundle\Event\PreResolveMediaEvent;
 use JoliCode\MediaBundle\Exception\ForbiddenPathException;
 use JoliCode\MediaBundle\Exception\PathAlreadyExistsException;
 use JoliCode\MediaBundle\Library\Library;
+use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Model\Media;
 use JoliCode\MediaBundle\Resolver\Resolver;
 use JoliCode\MediaBundle\Storage\Strategy\StorageStrategyInterface;
@@ -33,6 +34,13 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class OriginalStorage
 {
+    /**
+     * @var callable(): LibraryContainer|null
+     */
+    public static $libraryContainerInitializer;
+
+    private static LibraryContainer $libraryContainer;
+
     private Library $library;
 
     public function __construct(
@@ -51,9 +59,23 @@ class OriginalStorage
     public function __serialize(): array
     {
         return [
-            'urlPath',
-            'strategy',
+            'library' => $this->library->getName(),
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $libraryName = $data['library'] ?? null;
+
+        if (!\is_string($libraryName)) {
+            throw new \UnexpectedValueException('Invalid serialized original storage payload.');
+        }
+
+        // Handle only: Media re-attaches the live storage from the library.
+        $this->library = self::getLibraryContainer()->get($libraryName);
     }
 
     public function createDirectory(string $path): void
@@ -539,6 +561,19 @@ class OriginalStorage
     public function setLibrary(Library $library): void
     {
         $this->library = $library;
+    }
+
+    private static function getLibraryContainer(): LibraryContainer
+    {
+        if (!isset(self::$libraryContainer)) {
+            if (!isset(self::$libraryContainerInitializer)) {
+                throw new \LogicException('Library container initializer is not set.');
+            }
+
+            self::$libraryContainer = (self::$libraryContainerInitializer)();
+        }
+
+        return self::$libraryContainer;
     }
 
     private function getRouteName(): string

--- a/tests/src/Bridge/EasyAdmin/Controller/MediaAdminControllerTest.php
+++ b/tests/src/Bridge/EasyAdmin/Controller/MediaAdminControllerTest.php
@@ -119,7 +119,7 @@ class MediaAdminControllerTest extends WebTestCase
         $responseContent = $this->client->getResponse()->getContent();
         $this->assertIsString($responseContent);
 
-        $response = json_decode($responseContent, true);
+        $response = json_decode((string) $responseContent, true);
         $this->assertArrayHasKey('files', $response);
         $this->assertCount(1, $response['files']);
 
@@ -303,7 +303,7 @@ class MediaAdminControllerTest extends WebTestCase
     private function findInGalleryFromName(Crawler $crawler, string $name): Crawler
     {
         return $crawler->filter('ul.gallery-grid--files .gallery-grid-item__link')
-            ->reduce(static fn (Crawler $node): bool => str_contains($node->filter('.gallery-grid-item__name')->text(), $name))
+            ->reduce(static fn (Crawler $node): bool => str_contains((string) $node->filter('.gallery-grid-item__name')->text(), $name))
         ;
     }
 }

--- a/tests/src/Model/MediaTest.php
+++ b/tests/src/Model/MediaTest.php
@@ -5,7 +5,7 @@ namespace JoliCode\MediaBundle\Tests\Model;
 use JoliCode\MediaBundle\Binary\Binary;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
-use JoliCode\MediaBundle\Resolver\Resolver;
+use JoliCode\MediaBundle\Storage\OriginalStorage;
 use JoliCode\MediaBundle\Tests\BaseTestCase;
 
 class MediaTest extends BaseTestCase
@@ -162,18 +162,23 @@ class MediaTest extends BaseTestCase
 
     public function testSerializeUnserializeRestoresMedia(): void
     {
-        Media::$resolverInitializer = fn (): Resolver => $this->resolver;
+        $libraryContainerInitializer = fn () => $this->libraries;
+        Media::$libraryContainerInitializer = $libraryContainerInitializer;
+        OriginalStorage::$libraryContainerInitializer = $libraryContainerInitializer;
 
         $restored = unserialize(serialize($this->media));
 
         self::assertInstanceOf(Media::class, $restored);
         self::assertSame('test.jpg', $restored->getPath());
         self::assertSame('default', $restored->getLibrary()->getName());
+        self::assertSame($this->originalStorage, $restored->getStorage());
     }
 
     public function testUnserializeSupportsLegacyIndexedPayload(): void
     {
-        Media::$resolverInitializer = fn (): Resolver => $this->resolver;
+        $libraryContainerInitializer = fn () => $this->libraries;
+        Media::$libraryContainerInitializer = $libraryContainerInitializer;
+        OriginalStorage::$libraryContainerInitializer = $libraryContainerInitializer;
 
         $restored = (new \ReflectionClass(Media::class))->newInstanceWithoutConstructor();
         $restored->__unserialize([
@@ -183,5 +188,6 @@ class MediaTest extends BaseTestCase
 
         self::assertSame('test.jpg', $restored->getPath());
         self::assertSame('default', $restored->getLibrary()->getName());
+        self::assertSame($this->originalStorage, $restored->getStorage());
     }
 }

--- a/tests/src/Model/MediaTest.php
+++ b/tests/src/Model/MediaTest.php
@@ -158,4 +158,29 @@ class MediaTest extends BaseTestCase
 
         $media->store();
     }
+
+    public function testSerializeUnserializeRestoresMedia(): void
+    {
+        Media::$resolverInitializer = fn () => $this->resolver;
+
+        $restored = unserialize(serialize($this->media));
+
+        self::assertInstanceOf(Media::class, $restored);
+        self::assertSame('test.jpg', $restored->getPath());
+        self::assertSame('default', $restored->getLibrary()->getName());
+    }
+
+    public function testUnserializeSupportsLegacyIndexedPayload(): void
+    {
+        Media::$resolverInitializer = fn () => $this->resolver;
+
+        $restored = (new \ReflectionClass(Media::class))->newInstanceWithoutConstructor();
+        $restored->__unserialize([
+            0 => 'test.jpg',
+            1 => 'default',
+        ]);
+
+        self::assertSame('test.jpg', $restored->getPath());
+        self::assertSame('default', $restored->getLibrary()->getName());
+    }
 }

--- a/tests/src/Model/MediaTest.php
+++ b/tests/src/Model/MediaTest.php
@@ -3,10 +3,15 @@
 namespace JoliCode\MediaBundle\Tests\Model;
 
 use JoliCode\MediaBundle\Binary\Binary;
+use JoliCode\MediaBundle\Exception\InvalidSerializedMediaException;
+use JoliCode\MediaBundle\Library\Library;
+use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
+use JoliCode\MediaBundle\Model\MediaVariation;
 use JoliCode\MediaBundle\Storage\OriginalStorage;
 use JoliCode\MediaBundle\Tests\BaseTestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class MediaTest extends BaseTestCase
 {
@@ -160,11 +165,20 @@ class MediaTest extends BaseTestCase
         $media->store();
     }
 
+    public function testSerializeOnlyStoresScalars(): void
+    {
+        self::assertSame([
+            'path' => 'test.jpg',
+            'library' => 'default',
+        ], $this->media->__serialize());
+
+        // the storage is a service, it must never end up in the payload
+        self::assertStringNotContainsString(OriginalStorage::class, serialize($this->media));
+    }
+
     public function testSerializeUnserializeRestoresMedia(): void
     {
-        $libraryContainerInitializer = fn () => $this->libraries;
-        Media::$libraryContainerInitializer = $libraryContainerInitializer;
-        OriginalStorage::$libraryContainerInitializer = $libraryContainerInitializer;
+        Media::$libraryContainerInitializer = fn (): LibraryContainer => $this->libraries;
 
         $restored = unserialize(serialize($this->media));
 
@@ -174,11 +188,41 @@ class MediaTest extends BaseTestCase
         self::assertSame($this->originalStorage, $restored->getStorage());
     }
 
+    public function testUnserializeResetsTheRuntimeState(): void
+    {
+        Media::$libraryContainerInitializer = fn (): LibraryContainer => $this->libraries;
+        $this->media->addVariation(new MediaVariation($this->media, $this->variation));
+
+        $restored = unserialize(serialize($this->media));
+
+        self::assertInstanceOf(Media::class, $restored);
+        self::assertSame([], $restored->getVariations());
+    }
+
+    public function testUnserializeUsesTheCurrentLibraryContainer(): void
+    {
+        Media::$libraryContainerInitializer = fn (): LibraryContainer => $this->libraries;
+        $payload = serialize($this->media);
+
+        // the container is rebuilt whenever the kernel is rebooted: the restored
+        // media must not be attached to a stale one
+        $otherLibraries = new LibraryContainer(
+            new ServiceLocator([
+                'default' => fn (): Library => $this->libraries->get('custom'),
+            ]),
+            'default',
+        );
+        Media::$libraryContainerInitializer = static fn (): LibraryContainer => $otherLibraries;
+
+        $restored = unserialize($payload);
+
+        self::assertInstanceOf(Media::class, $restored);
+        self::assertSame($this->customOriginalStorage, $restored->getStorage());
+    }
+
     public function testUnserializeSupportsLegacyIndexedPayload(): void
     {
-        $libraryContainerInitializer = fn () => $this->libraries;
-        Media::$libraryContainerInitializer = $libraryContainerInitializer;
-        OriginalStorage::$libraryContainerInitializer = $libraryContainerInitializer;
+        Media::$libraryContainerInitializer = fn (): LibraryContainer => $this->libraries;
 
         $restored = (new \ReflectionClass(Media::class))->newInstanceWithoutConstructor();
         $restored->__unserialize([
@@ -189,5 +233,17 @@ class MediaTest extends BaseTestCase
         self::assertSame('test.jpg', $restored->getPath());
         self::assertSame('default', $restored->getLibrary()->getName());
         self::assertSame($this->originalStorage, $restored->getStorage());
+    }
+
+    public function testUnserializeThrowsOnInvalidPayload(): void
+    {
+        Media::$libraryContainerInitializer = fn (): LibraryContainer => $this->libraries;
+
+        $restored = (new \ReflectionClass(Media::class))->newInstanceWithoutConstructor();
+
+        $this->expectException(InvalidSerializedMediaException::class);
+        $this->expectExceptionMessage('Invalid serialized media payload.');
+
+        $restored->__unserialize(['path' => 'test.jpg']);
     }
 }

--- a/tests/src/Model/MediaTest.php
+++ b/tests/src/Model/MediaTest.php
@@ -5,6 +5,7 @@ namespace JoliCode\MediaBundle\Tests\Model;
 use JoliCode\MediaBundle\Binary\Binary;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
+use JoliCode\MediaBundle\Resolver\Resolver;
 use JoliCode\MediaBundle\Tests\BaseTestCase;
 
 class MediaTest extends BaseTestCase
@@ -161,7 +162,7 @@ class MediaTest extends BaseTestCase
 
     public function testSerializeUnserializeRestoresMedia(): void
     {
-        Media::$resolverInitializer = fn () => $this->resolver;
+        Media::$resolverInitializer = fn (): Resolver => $this->resolver;
 
         $restored = unserialize(serialize($this->media));
 
@@ -172,7 +173,7 @@ class MediaTest extends BaseTestCase
 
     public function testUnserializeSupportsLegacyIndexedPayload(): void
     {
-        Media::$resolverInitializer = fn () => $this->resolver;
+        Media::$resolverInitializer = fn (): Resolver => $this->resolver;
 
         $restored = (new \ReflectionClass(Media::class))->newInstanceWithoutConstructor();
         $restored->__unserialize([

--- a/tests/src/Storage/CacheKeyWithSubfolderTest.php
+++ b/tests/src/Storage/CacheKeyWithSubfolderTest.php
@@ -32,8 +32,6 @@ class CacheKeyWithSubfolderTest extends TestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->cache = new ArrayAdapter();
         $this->filesystem = new Filesystem(new InMemoryFilesystemAdapter());
         $this->mimeTypeGuesser = new MimeTypeGuesser(new MimeTypes(), new FileBinaryMimeTypeGuesser());

--- a/tests/src/Twig/Component/ImgTest.php
+++ b/tests/src/Twig/Component/ImgTest.php
@@ -31,8 +31,6 @@ class ImgTest extends BaseTestCase
 
     public static function setUpBeforeClass(): void
     {
-        parent::setUpBeforeClass();
-
         $container = static::getContainer();
 
         /** @var Converter */
@@ -78,8 +76,6 @@ class ImgTest extends BaseTestCase
 
     public static function tearDownAfterClass(): void
     {
-        parent::tearDownAfterClass();
-
         $container = static::getContainer();
 
         /** @var LibraryContainer */
@@ -106,7 +102,7 @@ class ImgTest extends BaseTestCase
         );
         $crawler = new Crawler(\sprintf('<!DOCTYPE html><html><body>%s</body></html>', $rendered));
         $img = $crawler->filterXPath('//body/*')->first();
-        $html = preg_replace(['/(\n\s*)+/', '/\s+/'], ['', ' '], $img->outerHtml());
+        $html = preg_replace(['/(\n\s*)+/', '/\s+/'], ['', ' '], (string) $img->outerHtml());
 
         if ($expected !== $html) {
             echo "\n\n" . $html . "\n\n";

--- a/tests/src/Twig/Component/PictureTest.php
+++ b/tests/src/Twig/Component/PictureTest.php
@@ -104,7 +104,7 @@ class PictureTest extends WebTestCase
         );
         $crawler = new Crawler(\sprintf('<!DOCTYPE html><html><body>%s</body></html>', $rendered));
         $img = $crawler->filterXPath('//body/*')->first();
-        $html = preg_replace(['/(\n\s*)+/', '/\s+/'], ['', ' '], $img->outerHtml());
+        $html = preg_replace(['/(\n\s*)+/', '/\s+/'], ['', ' '], (string) $img->outerHtml());
 
         // @phpstan-ignore-next-line
         if (Kernel::MAJOR_VERSION < 8 && !(Kernel::MAJOR_VERSION === 7 && Kernel::MINOR_VERSION === 4 && \PHP_VERSION_ID >= 80400)) {


### PR DESCRIPTION
## Summary
- add `Media::__unserialize()` so cached `Media` instances restore typed properties correctly
- keep backward compatibility with legacy indexed payloads (`[0 => path, 1 => library]`)
- register `Media::$resolverInitializer` in bundle boot (same resolver used by Doctrine media types)
- add regression tests for serialize/unserialize behavior

## Problem
When an entity containing `JoliCode\MediaBundle\Model\Media` is read from Doctrine second-level cache, unserialization may create dynamic properties (`$0`, `$1`) instead of restoring constructor-backed typed properties.

This can leave `$path` uninitialized and later crash at runtime when `getPath()` is accessed.

## Validation
- added tests in `tests/src/Model/MediaTest.php` for:
  - serialize/unserialize roundtrip
  - legacy indexed payload support
- syntax checks on modified files

Fixes #87

cc @xavierlacot