### PR TITLE
Fix move media modal with Easy admin 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+demo/application/config/reference.php
+
 # dependencies
 /composer.lock
 vendor

--- a/src/Bridge/EasyAdmin/templates/choose_directory.html.twig
+++ b/src/Bridge/EasyAdmin/templates/choose_directory.html.twig
@@ -10,7 +10,7 @@
 
 {% block rename_directory_container %}{% endblock %}
 
-{% block page_content %}
+{% block main %}
     {% block choose_directory_button %}
         {% if joli_media_admin_is_granted('MOVE', path: current_key) %}
             <a
@@ -28,6 +28,7 @@
     {% endblock %}
 
     {% block body_breadcrumb %}
+        {% set ea = ea() %}
         {{ include(ea.templatePath('flash_messages')) }}
         <div class="mt-3">
             {% if breadcrumb|length >= 1 %}


### PR DESCRIPTION
### Before
<img width="1359" height="674" alt="move-media-error" src="https://github.com/user-attachments/assets/f18c5b36-64cf-4fef-ba67-b9a78501bf60" />

### After
<img width="1625" height="687" alt="move-media-modal" src="https://github.com/user-attachments/assets/c83a9b72-8883-4b8a-a23a-1cfd3431745d" />
