### PR TITLE
fix(Sylius): Fix media get path

### DIFF
--- a/src/Bridge/Sylius/src/Doctrine/ORM/EntityWithMediaImageTrait.php
+++ b/src/Bridge/Sylius/src/Doctrine/ORM/EntityWithMediaImageTrait.php
@@ -34,4 +34,19 @@ trait EntityWithMediaImageTrait
     {
         return $this->media;
     }
+
+    public function getPath(): ?string
+    {
+        $mediaPath = $this->media?->getPath();
+
+        if (null !== $mediaPath) {
+            return $mediaPath;
+        }
+
+        if (property_exists($this, 'path')) {
+            return $this->path;
+        }
+
+        return null;
+    }
 }

--- a/src/Bridge/Sylius/templates/admin/shared/helper/product_image.html.twig
+++ b/src/Bridge/Sylius/templates/admin/shared/helper/product_image.html.twig
@@ -6,9 +6,9 @@
     }|merge(config) %}
 
     {% if product.imagesByType(config.type) is not empty %}
-        {% set path = product.imagesByType(config.type).first.path %}
+        {% set path = product.imagesByType(config.type).first.media.path|default(null) %}
     {% elseif product.images.first %}
-        {% set path = product.images.first.path %}
+        {% set path = product.images.first.media.path|default(null) %}
     {% else %}
         {% set path = null %}
     {% endif %}


### PR DESCRIPTION
I've challenged with ChatGPT but this solution seems to be the most pragmatic one.

> Variante élégante
> 
> Tu pourrais aussi :
> 
> ne plus persister path à terme,
> mais garder un getter virtuel via serializer/API.
> 
> Par contre ça implique :
> 
> custom hydration,
> ou remplacement complet des entités.
> 
> Donc probablement overkill pour le gain réel.
> 
> Ton approche actuelle est franchement la plus pragmatique.