### PR TITLE
feat(Sylius): Decorate the Sylius image uploader

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
         - src/Bridge/Sylius/src/Admin/Form/Extension
         - src/Bridge/Sylius/src/Doctrine/ORM/EntityWithMediaImageTrait.php
         - src/Bridge/Sylius/src/JoliMediaSyliusBundle.php
+        - src/Bridge/Sylius/src/Uploader/ImageUploader.php
         - src/JoliMediaBundle.php
     inferPrivatePropertyTypeFromConstructor: true
 

--- a/src/Bridge/Sylius/config/services.php
+++ b/src/Bridge/Sylius/config/services.php
@@ -11,7 +11,9 @@ use JoliCode\MediaBundle\Bridge\Sylius\Admin\Form\Type\UploadType;
 use JoliCode\MediaBundle\Bridge\Sylius\Admin\Grid\MediaGrid;
 use JoliCode\MediaBundle\Bridge\Sylius\Admin\Grid\Provider\MediaGridProvider;
 use JoliCode\MediaBundle\Bridge\Sylius\Config\Config;
+use JoliCode\MediaBundle\Bridge\Sylius\Uploader\ImageUploader;
 use JoliCode\MediaBundle\Bridge\Twig\JoliMediaAdminExtension;
+use Sylius\Component\Core\Uploader\ImageUploaderInterface;
 
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
@@ -92,4 +94,14 @@ return static function (ContainerConfigurator $container): void {
         ])
         ->tag('twig.extension')
     ;
+
+    if (interface_exists(ImageUploaderInterface::class)) {
+        $services->set('joli_media_sylius_admin.uploader.image', ImageUploader::class)
+            ->decorate('sylius.uploader.image')
+            ->args([
+                service('.inner'),
+                service('joli_media.library_container'),
+            ])
+        ;
+    }
 };

--- a/src/Bridge/Sylius/src/Uploader/ImageUploader.php
+++ b/src/Bridge/Sylius/src/Uploader/ImageUploader.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\MediaBundle\Bridge\Sylius\Uploader;
+
+use JoliCode\MediaBundle\Library\Library;
+use JoliCode\MediaBundle\Library\LibraryContainer;
+use JoliCode\MediaBundle\Storage\OriginalStorage;
+use Sylius\Component\Core\Model\ImageInterface;
+use Sylius\Component\Core\Uploader\ImageUploaderInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\HttpFoundation\File\File;
+
+#[AsDecorator(decorates: 'sylius.uploader.image')]
+final readonly class ImageUploader implements ImageUploaderInterface
+{
+    public function __construct(
+        private ImageUploaderInterface $imageUploader,
+        private LibraryContainer $libraries,
+    ) {
+    }
+
+    public function upload(ImageInterface $image): void
+    {
+        $this->imageUploader->upload($image);
+
+        $file = $image->getFile();
+
+        if (!$file instanceof File) {
+            return;
+        }
+
+        $media = $this->getOriginalStorage()->createMedia($image->getPath(), $file->getContent());
+
+        if (!method_exists($image, 'setMedia')) {
+            return;
+        }
+
+        $image->setMedia($media);
+    }
+
+    public function remove(string $path): bool
+    {
+        return $this->imageUploader->remove($path);
+    }
+
+    private function getOriginalStorage(): OriginalStorage
+    {
+        return $this->getLibrary()->getOriginalStorage();
+    }
+
+    private function getLibrary(): Library
+    {
+        return $this->libraries->getDefault();
+    }
+}

--- a/src/Bridge/Sylius/src/Uploader/ImageUploader.php
+++ b/src/Bridge/Sylius/src/Uploader/ImageUploader.php
@@ -9,10 +9,8 @@ use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Storage\OriginalStorage;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Uploader\ImageUploaderInterface;
-use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
 use Symfony\Component\HttpFoundation\File\File;
 
-#[AsDecorator(decorates: 'sylius.uploader.image')]
 final readonly class ImageUploader implements ImageUploaderInterface
 {
     public function __construct(
@@ -31,11 +29,11 @@ final readonly class ImageUploader implements ImageUploaderInterface
             return;
         }
 
-        $media = $this->getOriginalStorage()->createMedia($image->getPath(), $file->getContent());
-
-        if (!method_exists($image, 'setMedia')) {
+        if (!\is_callable([$image, 'setMedia'])) {
             return;
         }
+
+        $media = $this->getOriginalStorage()->createMedia($image->getPath(), $file->getContent());
 
         $image->setMedia($media);
     }


### PR DESCRIPTION
This ImageUploader allows to synchronize the media when using the Sylius image uploader. For example during data fixtures loading or using the legacy upload form.