### PR TITLE
Fix production cache:clear crash when DoctrineBundle's metadata warmer runs

### DIFF
--- a/src/Cache/MediaEntityMetadataWarmer.php
+++ b/src/Cache/MediaEntityMetadataWarmer.php
@@ -76,6 +76,11 @@ readonly class MediaEntityMetadataWarmer implements CacheWarmerInterface
         $this->cache->delete(self::MEDIA_DELETE_BEHAVIORS_CACHE_KEY);
         $this->cache->get(self::MEDIA_DELETE_BEHAVIORS_CACHE_KEY, static fn (): array => $mediaDeleteBehaviors);
 
+        // reset the managers so that later cache warmers (e.g. DoctrineBundle's optional metadata warmer, which requires a clean metadata factory) are not affected by the getAllMetadata() calls above
+        foreach (array_keys($this->managerRegistry->getManagers()) as $name) {
+            $this->managerRegistry->resetManager($name);
+        }
+
         return [];
     }
 }

--- a/src/Cache/MediaEntityMetadataWarmer.php
+++ b/src/Cache/MediaEntityMetadataWarmer.php
@@ -76,7 +76,8 @@ readonly class MediaEntityMetadataWarmer implements CacheWarmerInterface
         $this->cache->delete(self::MEDIA_DELETE_BEHAVIORS_CACHE_KEY);
         $this->cache->get(self::MEDIA_DELETE_BEHAVIORS_CACHE_KEY, static fn (): array => $mediaDeleteBehaviors);
 
-        // reset the managers so that later cache warmers (e.g. DoctrineBundle's optional metadata warmer, which requires a clean metadata factory) are not affected by the getAllMetadata() calls above
+        // Reset the managers so that later cache warmers (e.g. DoctrineBundle's optional metadata warmer,
+        // which requires a clean metadata factory) are not affected by the getAllMetadata() calls above.
         foreach (array_keys($this->managerRegistry->getManagers()) as $name) {
             $this->managerRegistry->resetManager($name);
         }

--- a/tests/src/Cache/MediaEntityMetadataWarmerTest.php
+++ b/tests/src/Cache/MediaEntityMetadataWarmerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JoliCode\MediaBundle\Tests\Cache;
+
+use Doctrine\Bundle\DoctrineBundle\CacheWarmer\DoctrineMetadataCacheWarmer;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use JoliCode\MediaBundle\Cache\MediaEntityMetadataWarmer;
+use JoliCode\MediaBundle\Tests\Application\Kernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class MediaEntityMetadataWarmerTest extends KernelTestCase
+{
+    public function testDoctrineMetadataCacheWarmerCanRunAfterwards(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+
+        /** @var MediaEntityMetadataWarmer $warmer */
+        $warmer = $container->get('joli_media.cache_warmer.media_entity_metadata');
+        $cacheDir = static::$kernel->getCacheDir();
+
+        $warmer->warmUp($cacheDir);
+
+        // DoctrineBundle's own metadata warmer is optional, so it runs after this
+        // one — and it refuses to warm a metadata factory that already holds
+        // loaded metadata (LogicException "must load metadata first").
+        /** @var ManagerRegistry $registry */
+        $registry = $container->get('doctrine');
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $registry->getManager();
+        self::assertSame([], $entityManager->getMetadataFactory()->getLoadedMetadata());
+
+        $phpArrayFile = $cacheDir . '/doctrine_metadata_warmer_test.php';
+        if (file_exists($phpArrayFile)) {
+            unlink($phpArrayFile);
+        }
+
+        (new DoctrineMetadataCacheWarmer($entityManager, $phpArrayFile))->warmUp($cacheDir);
+
+        self::assertFileExists($phpArrayFile);
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+}

--- a/tests/src/Cache/MediaEntityMetadataWarmerTest.php
+++ b/tests/src/Cache/MediaEntityMetadataWarmerTest.php
@@ -15,12 +15,12 @@ class MediaEntityMetadataWarmerTest extends KernelTestCase
 {
     public function testDoctrineMetadataCacheWarmerCanRunAfterwards(): void
     {
-        self::bootKernel();
+        $kernel = self::bootKernel();
         $container = static::getContainer();
 
         /** @var MediaEntityMetadataWarmer $warmer */
         $warmer = $container->get('joli_media.cache_warmer.media_entity_metadata');
-        $cacheDir = static::$kernel->getCacheDir();
+        $cacheDir = $kernel->getCacheDir();
 
         $warmer->warmUp($cacheDir);
 


### PR DESCRIPTION
`MediaEntityMetadataWarmer` calls `getAllMetadata()`, which loads every class metadata into the shared factory. DoctrineBundle's own `DoctrineMetadataCacheWarmer` is optional — it runs later, and only in non-debug kernels — and throws `DoctrineMetadataCacheWarmer must load metadata first, check priority of your warmers` when the factory already holds metadata. Result: every production `cache:clear` crashes in apps using the bundle with Doctrine ORM (dev/CI never see it, so it surfaces on deploy).

Fix: reset the entity managers after warming, so later warmers get a clean metadata factory.

The added test boots the test application, runs the bundle warmer, and then runs a real `DoctrineMetadataCacheWarmer` — red on current `main`, green with the fix.