### PR TITLE
[Sylius] Add Romanian and Russian translations

### DIFF
--- a/src/Bridge/Sylius/translations/JoliMediaSyliusBundle.ro.yaml
+++ b/src/Bridge/Sylius/translations/JoliMediaSyliusBundle.ro.yaml
@@ -1,0 +1,86 @@
+action:
+    choose_a_file: 'Alege un fișier'
+    copy: 'Copiază'
+    copied: 'Copiat'
+    delete_directory: 'Șterge acest dosar'
+    parent: 'Înapoi'
+    regenerate: 'Regenerează'
+    remove: 'Elimină'
+    rename: 'Redenumește'
+    rename_directory: 'Redenumește dosarul'
+    cancel: 'Anulează'
+    entity_actions: 'Acțiuni'
+    move_directory: 'Mută dosarul'
+    move_file: 'Mută acest fișier'
+    move_to_this_directory: 'Mută în acest dosar'
+    search: 'Caută'
+browser:
+    audio:
+        unsupported: 'Browserul dvs. nu suportă redarea audio.'
+    video:
+        unsupported: 'Browserul dvs. nu suportă redarea video.'
+directory:
+    label: 'Dosar'
+    create: 'Creează un dosar nou'
+    create_success: 'Dosarul „%directory%” a fost creat.'
+    create_failure: 'Dosarul „%directory%” nu a putut fi creat: %error%'
+    name: 'Numele dosarului'
+    name_required: 'Numele dosarului este obligatoriu'
+    rename_success: 'Dosarul „%from%” a fost redenumit în „%to%”.'
+    move_success: 'Dosarul „%from%” a fost mutat în „%to%”.'
+media:
+    add: 'Adaugă imagini'
+    dimensions: 'Dimensiuni'
+    name: 'Nume'
+    size:
+        label_long: 'Mărimea fișierului'
+    type:
+        label: 'Tip'
+        label_long: 'Tipul fișierului'
+        audio: 'Audio'
+        csv: 'CSV'
+        excel: 'Excel'
+        file: 'Fișier'
+        html: 'HTML'
+        image: 'Imagine'
+        pdf: 'PDF'
+        powerpoint: 'PowerPoint'
+        text: 'Text'
+        video: 'Video'
+        word: 'Word'
+        xml: 'XML'
+        zip: 'ZIP'
+    unavailable:
+        simple: 'Nicio imagine selectată.'
+    url:
+        label_long: 'Adresa fișierului'
+    inaccessible:
+        explanation: 'Fișierul „%media%” nu este accesibil. Poate a fost șters sau mutat.'
+        label: 'Fișier inaccesibil'
+    error:
+        required: 'Alegeți un fișier.'
+    move_modal:
+        title: 'Mutarea fișierului'
+        content: 'Sigur mutați acest fișier în dosarul %directory%?'
+    move_success: 'Fișierul %from% a fost mutat în %to%.'
+    move_failure: 'Fișierul nu a putut fi mutat din %from% în %to%. Eroare: %error%'
+    rename_success: 'Fișierul %from% a fost redenumit în %to%.'
+    search_label: 'Caută imagini…'
+    upload:
+        dropzone:
+            default_message: 'Trageți fișierele aici pentru încărcare'
+            fallback_message: 'Browserul dvs. nu suportă încărcarea prin tragere.'
+            fallback_text: 'Folosiți formularul de mai jos pentru a încărca fișierele.'
+            file_too_big: 'Fișierul este prea mare ({{filesize}} MiB). Maximul: {{maxFilesize}} MiB.'
+            invalid_file_type: 'Nu puteți încărca fișiere de acest tip.'
+            max_files_exceeded: 'Nu mai puteți încărca alte fișiere.'
+document:
+    download: 'Descarcă documentul'
+no_file_found: 'Niciun fișier găsit'
+preview:
+    unavailable: 'Previzualizarea nu este disponibilă.'
+root: 'Rădăcină'
+variation:
+    label: 'Variantă'
+    stored: 'Stocată?'
+media_library: 'Media'

--- a/src/Bridge/Sylius/translations/JoliMediaSyliusBundle.ru.yaml
+++ b/src/Bridge/Sylius/translations/JoliMediaSyliusBundle.ru.yaml
@@ -1,0 +1,86 @@
+action:
+    choose_a_file: 'Выбрать файл'
+    copy: 'Копировать'
+    copied: 'Скопировано'
+    delete_directory: 'Удалить эту папку'
+    parent: 'Назад'
+    regenerate: 'Пересоздать'
+    remove: 'Убрать'
+    rename: 'Переименовать'
+    rename_directory: 'Переименовать папку'
+    cancel: 'Отмена'
+    entity_actions: 'Действия'
+    move_directory: 'Переместить папку'
+    move_file: 'Переместить этот файл'
+    move_to_this_directory: 'Переместить в эту папку'
+    search: 'Поиск'
+browser:
+    audio:
+        unsupported: 'Ваш браузер не поддерживает аудио.'
+    video:
+        unsupported: 'Ваш браузер не поддерживает видео.'
+directory:
+    label: 'Папка'
+    create: 'Создать новую папку'
+    create_success: 'Папка «%directory%» создана.'
+    create_failure: 'Не удалось создать папку «%directory%»: %error%'
+    name: 'Название папки'
+    name_required: 'Название папки обязательно'
+    rename_success: 'Папка «%from%» переименована в «%to%».'
+    move_success: 'Папка «%from%» перемещена в «%to%».'
+media:
+    add: 'Добавить изображения'
+    dimensions: 'Размеры'
+    name: 'Название'
+    size:
+        label_long: 'Размер файла'
+    type:
+        label: 'Тип'
+        label_long: 'Тип файла'
+        audio: 'Аудио'
+        csv: 'CSV'
+        excel: 'Excel'
+        file: 'Файл'
+        html: 'HTML'
+        image: 'Изображение'
+        pdf: 'PDF'
+        powerpoint: 'PowerPoint'
+        text: 'Текст'
+        video: 'Видео'
+        word: 'Word'
+        xml: 'XML'
+        zip: 'ZIP'
+    unavailable:
+        simple: 'Изображение не выбрано.'
+    url:
+        label_long: 'Адрес файла'
+    inaccessible:
+        explanation: 'Файл «%media%» недоступен. Возможно, он был удалён или перемещён.'
+        label: 'Недоступный файл'
+    error:
+        required: 'Выберите файл.'
+    move_modal:
+        title: 'Перемещение файла'
+        content: 'Действительно переместить этот файл в папку %directory%?'
+    move_success: 'Файл %from% перемещён в %to%.'
+    move_failure: 'Не удалось переместить файл из %from% в %to%. Ошибка: %error%'
+    rename_success: 'Файл %from% переименован в %to%.'
+    search_label: 'Поиск изображений…'
+    upload:
+        dropzone:
+            default_message: 'Перетащите файлы сюда для загрузки'
+            fallback_message: 'Ваш браузер не поддерживает загрузку перетаскиванием.'
+            fallback_text: 'Используйте форму ниже для загрузки файлов.'
+            file_too_big: 'Файл слишком большой ({{filesize}} МиБ). Максимум: {{maxFilesize}} МиБ.'
+            invalid_file_type: 'Файлы этого типа загружать нельзя.'
+            max_files_exceeded: 'Больше файлов загрузить нельзя.'
+document:
+    download: 'Скачать документ'
+no_file_found: 'Файлы не найдены'
+preview:
+    unavailable: 'Предпросмотр недоступен.'
+root: 'Корень'
+variation:
+    label: 'Вариант'
+    stored: 'Сохранён?'
+media_library: 'Медиа'


### PR DESCRIPTION
Adds `ro` and `ru` catalogues for the Sylius bridge, covering the full key set of the `en` catalogue. In use in a production Romanian/Russian admin.