### PR TITLE
EasyAdmin bridge: have the media paginator implement EntityPaginatorInterface

### DIFF
--- a/demo/castor.php
+++ b/demo/castor.php
@@ -77,6 +77,13 @@ function demo_install($useLocalBundle = true): void
                 json_encode($composerJson, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES) . "\n",
             );
             copy("{$basePath}/symfony.lock", "{$basePath}/docker-symfony.lock");
+
+            // a docker-composer.lock generated before the last composer.lock update may
+            // not satisfy the current constraints, which makes composer install fail
+            $dockerComposerLock = "{$basePath}/docker-composer.lock";
+            if (is_file($dockerComposerLock) && filemtime($dockerComposerLock) < filemtime("{$basePath}/composer.lock")) {
+                unlink($dockerComposerLock);
+            }
         }
 
         io()->section('Installing PHP dependencies');

--- a/src/Bridge/EasyAdmin/src/Controller/MediaAdminController.php
+++ b/src/Bridge/EasyAdmin/src/Controller/MediaAdminController.php
@@ -312,7 +312,7 @@ class MediaAdminController extends AbstractController
             throw new BadRequestException('The requested page number is out of range.');
         }
 
-        $paginator = $this->mediaPaginator->paginate($paginatedMedias, $routeName, $currentKey);
+        $paginator = $this->mediaPaginator->paginateMedias($paginatedMedias, $routeName, $currentKey);
 
         return new Response($this->twig->render('@JoliMediaEasyAdmin/list.html.twig', [
             'base_template' => \sprintf('@JoliMediaEasyAdmin/%s.html.twig', $template),

--- a/src/Bridge/EasyAdmin/src/Paginator/MediaPaginator.php
+++ b/src/Bridge/EasyAdmin/src/Paginator/MediaPaginator.php
@@ -2,15 +2,19 @@
 
 namespace JoliCode\MediaBundle\Bridge\EasyAdmin\Paginator;
 
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityPaginatorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\PaginatorDto;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use JoliCode\MediaBundle\Model\Media;
 
 /**
  * Paginator adapter for media files to work with EasyAdmin's pagination template.
- * This adapter provides the same interface as EasyAdmin's EntityPaginator
- * but works with array data instead of Doctrine entities.
+ * This adapter implements EasyAdmin's EntityPaginatorInterface (required by the
+ * pagination Twig component since EasyAdmin 5) but works with array data instead
+ * of Doctrine entities: media must be paginated with paginateMedias(), not paginate().
  */
-class MediaPaginator
+class MediaPaginator implements EntityPaginatorInterface
 {
     private int $currentPage;
 
@@ -32,10 +36,15 @@ class MediaPaginator
     ) {
     }
 
+    public function paginate(PaginatorDto $paginatorDto, QueryBuilder $queryBuilder): self
+    {
+        throw new \BadMethodCallException('MediaPaginator does not paginate Doctrine entities, use paginateMedias() instead.');
+    }
+
     /**
      * @param array{items: array<Media>, total: int, page: int, perPage: int} $paginationData
      */
-    public function paginate(array $paginationData, string $routeName, string $currentKey): self
+    public function paginateMedias(array $paginationData, string $routeName, string $currentKey): self
     {
         $this->currentPage = $paginationData['page'];
         $this->pageSize = $paginationData['perPage'];
@@ -117,6 +126,15 @@ class MediaPaginator
         return $this->numResults > $this->pageSize;
     }
 
+    public function isOutOfRange(): bool
+    {
+        if (1 === $this->currentPage) {
+            return false;
+        }
+
+        return $this->currentPage < 1 || $this->currentPage > $this->getLastPage();
+    }
+
     public function getNumResults(): int
     {
         return $this->numResults;
@@ -128,5 +146,15 @@ class MediaPaginator
     public function getResults(): array
     {
         return $this->results;
+    }
+
+    public function getResultsAsJson(): string
+    {
+        return json_encode([
+            'results' => array_map(static fn (Media $media): array => [
+                'entityId' => $media->getPath(),
+                'entityAsString' => $media->getFilename(),
+            ], $this->results),
+        ], \JSON_THROW_ON_ERROR);
     }
 }


### PR DESCRIPTION
Since EA 5.2 and https://github.com/EasyCorp/EasyAdminBundle/commit/4f0a4adc21a8918c4c4ee141507da7b391313a46#diff-f7c93e6991d9dadb7174facba324b0d048e98494de5b7fba08c484a0697f289e, EasyAdmin templates rely on the `twig:ea:Pagination` component to dis^lay pagination controls, and this component requires the paginator to implement `EntityPaginatorInterface.