### PR TITLE
Fix custom pre-processor usage

### DIFF
--- a/demo/application/config/packages/joli_media.yaml
+++ b/demo/application/config/packages/joli_media.yaml
@@ -119,6 +119,7 @@ joli_media:
                             height: 100
 
     pre_processors:
+        - App\Media\PreProcessor\PassthroughPreProcessor
         - JoliCode\MediaBundle\PreProcessor\ExifRemovalPreProcessor
 
     processors: ~

--- a/demo/application/src/Media/PreProcessor/PassthroughPreProcessor.php
+++ b/demo/application/src/Media/PreProcessor/PassthroughPreProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Media\PreProcessor;
+
+use JoliCode\MediaBundle\Binary\Binary;
+use JoliCode\MediaBundle\Model\Format;
+use JoliCode\MediaBundle\Model\MediaVariation;
+use JoliCode\MediaBundle\PreProcessor\AbstractPreProcessor;
+use JoliCode\MediaBundle\PreProcessor\PreProcessorInterface;
+use Psr\Log\LoggerInterface;
+
+readonly class PassthroughPreProcessor extends AbstractPreProcessor implements PreProcessorInterface
+{
+    public function __construct(
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function process(Binary $binary, MediaVariation $mediaVariation): Binary
+    {
+        if (!$this->supports($binary)) {
+            return $binary;
+        }
+
+        $this->logger?->info('Traversing the passthrough pre-processor', [
+            'mimeType' => $binary->getMimeType(),
+            'format' => $binary->getFormat(),
+        ]);
+
+        return $binary;
+    }
+
+    public function supports(Binary $binary): bool
+    {
+        return \in_array($binary->getFormat(), [Format::JPEG->value, Format::TIFF->value], true);
+    }
+}

--- a/src/JoliMediaBundle.php
+++ b/src/JoliMediaBundle.php
@@ -106,7 +106,7 @@ class JoliMediaBundle extends AbstractBundle
             array_unshift($config['pre_processors'], HeifPreProcessor::class);
         }
 
-        $this->createPreProcessorServices($container, $config['pre_processors']);
+        $this->createPreProcessorServices($container, $builder, $config['pre_processors']);
 
         // processors
         $this->createProcessorServices($container, $config['processors']);
@@ -972,7 +972,7 @@ class JoliMediaBundle extends AbstractBundle
         }
     }
 
-    private function createPreProcessorServices(ContainerConfigurator $container, array $preProcessorsConfig): void
+    private function createPreProcessorServices(ContainerConfigurator $container, ContainerBuilder $builder, array $preProcessorsConfig): void
     {
         if (in_array(HeifPreProcessor::class, $preProcessorsConfig)) {
             if (!interface_exists(ImagineInterface::class)) {
@@ -986,10 +986,18 @@ class JoliMediaBundle extends AbstractBundle
         }
 
         foreach ($preProcessorsConfig as $preProcessorClass) {
-            $container->services()
-                ->get($preProcessorClass)
-                ->tag('joli_media.pre_processor', ['name' => $preProcessorClass])
-            ;
+            if ($builder->hasDefinition($preProcessorClass)) {
+                $container->services()
+                    ->get($preProcessorClass)
+                    ->tag('joli_media.pre_processor', ['name' => $preProcessorClass])
+                ;
+            } else {
+                // pre-processors defined outside the bundle are not visible from the
+                // extension, tag them through autoconfiguration instead
+                $builder->registerForAutoconfiguration($preProcessorClass)
+                    ->addTag('joli_media.pre_processor', ['name' => $preProcessorClass])
+                ;
+            }
         }
     }
 


### PR DESCRIPTION
Defining a custom pre-processor (living in the app) at the main level was throwing a ServiceNotFoundException.
This fixes that behavior and allows custom pre-processors to be used across the whole library.