### PR TITLE
Add the "process_timeout" configuration directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- feature - Add a global `process_timeout` configuration directive to control the timeout of the external binary processes, with per processor, pre-processor and post-processor overrides
+
 ## [0.6.1] - 2026-07-27
 
 - fix - Allow to use pre-processors defined outside the bundle at the global state

--- a/config/services.php
+++ b/config/services.php
@@ -232,6 +232,7 @@ return static function (ContainerConfigurator $container): void {
         ->args([
             '$exiftoolBinary' => param('joli_media.binary.exiftool'),
             '$logger' => service('logger')->ignoreOnInvalid(),
+            '$processTimeout' => param('joli_media.process_timeout'),
         ])
 
         ->set(HeifPreProcessor::class, HeifPreProcessor::class)

--- a/demo/application/config/packages/joli_media.yaml
+++ b/demo/application/config/packages/joli_media.yaml
@@ -118,8 +118,14 @@ joli_media:
                             width: 100
                             height: 100
 
+    # timeout, in seconds, of the external binary processes created by the
+    # processors, pre-processors and post-processors (use 0 to disable it)
+    process_timeout: 60
+
     pre_processors:
-        - App\Media\PreProcessor\PassthroughPreProcessor
-        - JoliCode\MediaBundle\PreProcessor\ExifRemovalPreProcessor
+        App\Media\PreProcessor\PassthroughPreProcessor: ~
+        JoliCode\MediaBundle\PreProcessor\ExifRemovalPreProcessor:
+            # overrides the global process_timeout for this pre-processor
+            process_timeout: 120
 
     processors: ~

--- a/doc/getting-started/configuration.rst
+++ b/doc/getting-started/configuration.rst
@@ -5,8 +5,10 @@ The bundle can be configured in the ``config/packages/joli_media.yaml`` file wit
 
 - ``libraries``: defines the media libraries configuration
 - ``default_library``: defines the library to use by default
+- ``pre_processors``: defines the media pre-processors configuration
 - ``processors``: defines the media processors configuration
 - ``post_processors``: defines the media post processors configuration
+- ``process_timeout``: defines the default timeout of the external processes ran by the processors
 
 Libraries configuration
 -----------------------
@@ -51,6 +53,20 @@ Post-processors configuration
 -----------------------------
 
 Post-processors can be used to optimize the media after the transformation. Read the `Post-processors documentation <../variations/post-processors.rst>`_ to learn more about how to configure them.
+
+External processes timeout
+--------------------------
+
+Most processors, pre-processors and post-processors call external binaries (``cwebp``, ``gifsicle``, ``exiftool``, etc.) in dedicated processes. The ``process_timeout`` directive defines the default timeout, in seconds, applied to these processes. It defaults to ``60`` seconds, and can be set to ``0`` to disable the timeout:
+
+.. code-block:: yaml
+
+    joli_media:
+        process_timeout: 120
+
+This value can be overridden for each processor, pre-processor or post-processor that uses an external binary - see the `Processors <../variations/processors.rst>`_, `Pre-processors <../variations/pre-processors.rst>`_ and `Post-processors <../variations/post-processors.rst>`_ documentation pages.
+
+The configured value is also exposed as the ``joli_media.process_timeout`` container parameter, so it can be re-used in your own service definitions.
 
 Example minimal configuration
 -----------------------------

--- a/doc/variations/post-processors.rst
+++ b/doc/variations/post-processors.rst
@@ -22,6 +22,18 @@ While there are many other image optimization tools available, these are the one
 
 Each post-processor has a ``binary`` key that defines the path to the binary to use, and an ``options`` key that defines the options to use when executing the binary. The default settings provide a good balance between quality and performance to make sure that the media is optimized while keeping a good quality.
 
+Post-processors execute their binary in an external process, which times out after the duration defined in the global ``joli_media.process_timeout`` directive (60 seconds by default). Each post-processor can override this value using its ``process_timeout`` key, in seconds. Use ``0`` to disable the timeout:
+
+.. code-block:: yaml
+
+    joli_media:
+        # applies to all the external processes created by the bundle
+        process_timeout: 120
+        post_processors:
+            jpegoptim:
+                # overrides the global timeout for the jpegoptim post-processor
+                process_timeout: 30
+
 Default configuration
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/variations/pre-processors.rst
+++ b/doc/variations/pre-processors.rst
@@ -19,6 +19,31 @@ The pre-processors configuration is defined in the ``pre_processors`` key of the
 
 In the example above, the ``AutoRotateImagePreProcessor`` will be applied to the media before any of its variation is computed. The pre-processors are executed sequentially, in the order they are defined in the configuration file.
 
+Pre-processors that use an external binary (such as the ``ExifRemovalPreProcessor``) execute it in an external process, which times out after the duration defined in the global ``joli_media.process_timeout`` directive (60 seconds by default). To override this value for a given pre-processor, use the alternative map syntax of the ``pre_processors`` configuration and define its ``process_timeout`` key, in seconds (``0`` disables the timeout):
+
+.. code-block:: yaml
+
+    joli_media:
+        pre_processors:
+            App\Media\PreProcessor\AutoRotateImagePreProcessor: ~
+            JoliCode\MediaBundle\PreProcessor\ExifRemovalPreProcessor:
+                process_timeout: 120
+
+For pre-processors defined in your application, the ``process_timeout`` value is passed to the ``$processTimeout`` argument of the service constructor, which must hence be declared, and returned by an override of the ``getProcessTimeout()`` method::
+
+    public function __construct(
+        private ImagineInterface $imagine,
+        private ?float $processTimeout = null,
+    ) {
+    }
+
+    protected function getProcessTimeout(): ?float
+    {
+        return $this->processTimeout;
+    }
+
+Pre-processors that declare this argument without configuring a ``process_timeout`` can inherit the global value by binding the ``joli_media.process_timeout`` container parameter in their service definition.
+
 The pre-processors configuration can also be defined within a specific variation configuration, under the ``variations`` key of the ``joli_media`` configuration. For example:
 
 .. code-block:: yaml

--- a/doc/variations/processors.rst
+++ b/doc/variations/processors.rst
@@ -66,6 +66,24 @@ All processors - except the ``imagine`` processor - have a ``binary`` key that d
 
 The ``imagine`` processor does not use a binary, it uses the Imagine library to process images. The ``driver`` key can be used to define which Imagine driver to use (e.g. ``gd``, ``imagick`` or ``gmagick``). If not set, ``gmagick`` will be used.
 
+Processes timeout
+~~~~~~~~~~~~~~~~~
+
+The processors that use a binary execute it in an external process, which times out after the duration defined in the global ``joli_media.process_timeout`` directive (60 seconds by default). Each of these processors can override this value using its ``process_timeout`` key, in seconds. Use ``0`` to disable the timeout:
+
+.. code-block:: yaml
+
+    joli_media:
+        # applies to all the external processes created by the bundle
+        process_timeout: 120
+        processors:
+            cwebp:
+                # overrides the global timeout for the cwebp processor
+                process_timeout: 300
+            gifsicle:
+                # disables the timeout for the gifsicle processor
+                process_timeout: 0
+
 cwebp processor options
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/JoliMediaBundle.php
+++ b/src/JoliMediaBundle.php
@@ -17,6 +17,7 @@ use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\PreProcessor\HeifPreProcessor;
 use JoliCode\MediaBundle\Processor\Imagine;
 use JoliCode\MediaBundle\Transformer\Resize\Mode;
+use Symfony\Component\Config\Definition\Builder\FloatNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
@@ -58,6 +59,11 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('default_library')
                     ->defaultValue(null)
                 ->end()
+                ->floatNode('process_timeout')
+                    ->min(0)
+                    ->defaultValue(60.0)
+                    ->info('Default timeout, in seconds, of the external binary processes created by the processors, pre-processors and post-processors. Use 0 to disable the timeout.')
+                ->end()
                 ->append($this->addLibrariesNode())
                 ->append($this->addPreProcessorsNode())
                 ->append($this->addProcessorsNode())
@@ -90,6 +96,8 @@ class JoliMediaBundle extends AbstractBundle
         $builder->setParameter('joli_media.binary.oxipng', '%env(JOLI_MEDIA_OXIPNG_BINARY)%');
         $builder->setParameter('joli_media.binary.pngquant', '%env(JOLI_MEDIA_PNGQUANT_BINARY)%');
 
+        $builder->setParameter('joli_media.process_timeout', $config['process_timeout']);
+
         // libraries
         foreach ($config['libraries'] as $libraryName => $libraryConfig) {
             $this->createLibraryService($container, $builder, $libraryName, $libraryConfig);
@@ -101,18 +109,18 @@ class JoliMediaBundle extends AbstractBundle
         ;
 
         // pre-processors
-        if (!in_array(HeifPreProcessor::class, $config['pre_processors']) && interface_exists(ImagineInterface::class)) {
+        if (!\array_key_exists(HeifPreProcessor::class, $config['pre_processors']) && interface_exists(ImagineInterface::class)) {
             // Automatically add the Heif pre-processor if it is not manually configured and Imagine is available
-            array_unshift($config['pre_processors'], HeifPreProcessor::class);
+            $config['pre_processors'] = [HeifPreProcessor::class => []] + $config['pre_processors'];
         }
 
         $this->createPreProcessorServices($container, $builder, $config['pre_processors']);
 
         // processors
-        $this->createProcessorServices($container, $config['processors']);
+        $this->createProcessorServices($container, $config['processors'], $config['process_timeout']);
 
         // post-processors
-        $this->createPostProcessorServices($container, $config['post_processors']);
+        $this->createPostProcessorServices($container, $config['post_processors'], $config['process_timeout']);
     }
 
     public function prependExtension(ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void
@@ -302,7 +310,7 @@ class JoliMediaBundle extends AbstractBundle
                         ->end()
                     ->end()
                     ->append($this->addPostProcessorOptionsNode())
-                    ->append($this->addPreProcessorsNode())
+                    ->append($this->addVariationPreProcessorsNode())
                     ->append($this->addProcessorOptionsNode())
                     ->append($this->addVotersNode())
                 ->end()
@@ -363,6 +371,51 @@ class JoliMediaBundle extends AbstractBundle
     }
 
     private function addPreProcessorsNode(): NodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('pre_processors');
+        $node = $treeBuilder->getRootNode();
+
+        return $node
+            ->info('Pre-processors to register, indexed by their class name. A plain list of class names is also allowed.')
+            ->useAttributeAsKey('class')
+            ->beforeNormalization()
+                ->ifArray()
+                ->then(static function (array $values): array {
+                    $preProcessors = [];
+
+                    foreach ($values as $class => $preProcessorConfig) {
+                        if (\is_int($class) && \is_string($preProcessorConfig)) {
+                            $preProcessors[$preProcessorConfig] = [];
+                        } else {
+                            $preProcessors[$class] = $preProcessorConfig ?? [];
+                        }
+                    }
+
+                    return $preProcessors;
+                })
+            ->end()
+            ->arrayPrototype()
+                ->children()
+                    ->append($this->addProcessTimeoutNode())
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addProcessTimeoutNode(): NodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('process_timeout', 'float');
+        /** @var FloatNodeDefinition $node */
+        $node = $treeBuilder->getRootNode();
+
+        return $node
+            ->min(0)
+            ->defaultNull()
+            ->info('Overrides the global "process_timeout" configuration, in seconds, for the external binary processes created by this processor. Use 0 to disable the timeout.')
+        ;
+    }
+
+    private function addVariationPreProcessorsNode(): NodeDefinition
     {
         $treeBuilder = new TreeBuilder('pre_processors');
         $node = $treeBuilder->getRootNode();
@@ -458,6 +511,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('identify_binary')
                     ->defaultValue('%joli_media.binary.identify%')
                 ->end()
+                ->append($this->addProcessTimeoutNode())
                 ->append($this->addCwebpProcessorOptionsNode('options'))
             ->end()
         ;
@@ -553,6 +607,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('binary')
                     ->defaultValue('%joli_media.binary.gif2webp%')
                 ->end()
+                ->append($this->addProcessTimeoutNode())
                 ->append($this->addGif2webpProcessorOptionsNode('options'))
             ->end()
         ;
@@ -600,6 +655,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('binary')
                     ->defaultValue('%joli_media.binary.gifsicle%')
                 ->end()
+                ->append($this->addProcessTimeoutNode())
                 ->append($this->addGifsicleProcessorOptionsNode('options'))
             ->end()
         ;
@@ -698,6 +754,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('binary')
                     ->defaultValue('%joli_media.binary.gifsicle%')
                 ->end()
+                ->append($this->addProcessTimeoutNode())
                 ->append($this->addGifsiclePostProcessorOptionsNode('options'))
             ->end()
         ;
@@ -745,6 +802,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('binary')
                     ->defaultValue('%joli_media.binary.jpegoptim%')
                 ->end()
+                ->append($this->addProcessTimeoutNode())
                 ->append($this->addJpegoptimPostProcessorOptionsNode('options'))
             ->end()
         ;
@@ -790,6 +848,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('binary')
                     ->defaultValue('%joli_media.binary.mozjpeg%')
                 ->end()
+                ->append($this->addProcessTimeoutNode())
                 ->append($this->addMozjpegPostProcessorOptionsNode('options'))
             ->end()
         ;
@@ -835,6 +894,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('binary')
                     ->defaultValue('%joli_media.binary.oxipng%')
                 ->end()
+                ->append($this->addProcessTimeoutNode())
                 ->append($this->addOxipngPostProcessorOptionsNode('options'))
             ->end()
         ;
@@ -884,6 +944,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->scalarNode('binary')
                     ->defaultValue('%joli_media.binary.pngquant%')
                 ->end()
+                ->append($this->addProcessTimeoutNode())
                 ->append($this->addPngquantPostProcessorOptionsNode('options'))
             ->end()
         ;
@@ -915,7 +976,7 @@ class JoliMediaBundle extends AbstractBundle
         ;
     }
 
-    private function createPostProcessorServices(ContainerConfigurator $container, array $postProcessorsConfig): void
+    private function createPostProcessorServices(ContainerConfigurator $container, array $postProcessorsConfig, float $defaultProcessTimeout): void
     {
         $postProcessorContainerService = $container->services()
             ->get('joli_media.post_processor_container')
@@ -926,6 +987,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->get('.joli_media.post_processor.gifsicle')
                 ->arg('$binary', $postProcessorsConfig['gifsicle']['binary'])
                 ->arg('$options', $postProcessorsConfig['gifsicle']['options'])
+                ->arg('$processTimeout', $postProcessorsConfig['gifsicle']['process_timeout'] ?? $defaultProcessTimeout)
             ;
 
             $postProcessorContainerService->call('add', ['gifsicle', service('.joli_media.post_processor.gifsicle')]);
@@ -936,6 +998,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->get('.joli_media.post_processor.jpegoptim')
                 ->arg('$binary', $postProcessorsConfig['jpegoptim']['binary'])
                 ->arg('$options', $postProcessorsConfig['jpegoptim']['options'])
+                ->arg('$processTimeout', $postProcessorsConfig['jpegoptim']['process_timeout'] ?? $defaultProcessTimeout)
             ;
 
             $postProcessorContainerService->call('add', ['jpegoptim', service('.joli_media.post_processor.jpegoptim')]);
@@ -946,6 +1009,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->get('.joli_media.post_processor.mozjpeg')
                 ->arg('$binary', $postProcessorsConfig['mozjpeg']['binary'])
                 ->arg('$options', $postProcessorsConfig['mozjpeg']['options'])
+                ->arg('$processTimeout', $postProcessorsConfig['mozjpeg']['process_timeout'] ?? $defaultProcessTimeout)
             ;
 
             $postProcessorContainerService->call('add', ['mozjpeg', service('.joli_media.post_processor.mozjpeg')]);
@@ -956,6 +1020,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->get('.joli_media.post_processor.pngquant')
                 ->arg('$binary', $postProcessorsConfig['pngquant']['binary'])
                 ->arg('$options', $postProcessorsConfig['pngquant']['options'])
+                ->arg('$processTimeout', $postProcessorsConfig['pngquant']['process_timeout'] ?? $defaultProcessTimeout)
             ;
 
             $postProcessorContainerService->call('add', ['pngquant', service('.joli_media.post_processor.pngquant')]);
@@ -966,6 +1031,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->get('.joli_media.post_processor.oxipng')
                 ->arg('$binary', $postProcessorsConfig['oxipng']['binary'])
                 ->arg('$options', $postProcessorsConfig['oxipng']['options'])
+                ->arg('$processTimeout', $postProcessorsConfig['oxipng']['process_timeout'] ?? $defaultProcessTimeout)
             ;
 
             $postProcessorContainerService->call('add', ['oxipng', service('.joli_media.post_processor.oxipng')]);
@@ -974,7 +1040,7 @@ class JoliMediaBundle extends AbstractBundle
 
     private function createPreProcessorServices(ContainerConfigurator $container, ContainerBuilder $builder, array $preProcessorsConfig): void
     {
-        if (in_array(HeifPreProcessor::class, $preProcessorsConfig)) {
+        if (\array_key_exists(HeifPreProcessor::class, $preProcessorsConfig)) {
             if (!interface_exists(ImagineInterface::class)) {
                 throw new \LogicException('The HeifPreProcessor requires the Imagine library to be installed. Please install the "imagine/imagine" package.');
             }
@@ -985,23 +1051,34 @@ class JoliMediaBundle extends AbstractBundle
             ;
         }
 
-        foreach ($preProcessorsConfig as $preProcessorClass) {
+        foreach ($preProcessorsConfig as $preProcessorClass => $preProcessorConfig) {
+            $processTimeout = $preProcessorConfig['process_timeout'] ?? null;
+
             if ($builder->hasDefinition($preProcessorClass)) {
-                $container->services()
+                $preProcessorService = $container->services()
                     ->get($preProcessorClass)
                     ->tag('joli_media.pre_processor', ['name' => $preProcessorClass])
                 ;
+
+                if (null !== $processTimeout) {
+                    $preProcessorService->arg('$processTimeout', $processTimeout);
+                }
             } else {
                 // pre-processors defined outside the bundle are not visible from the
                 // extension, tag them through autoconfiguration instead
-                $builder->registerForAutoconfiguration($preProcessorClass)
+                $autoconfiguration = $builder->registerForAutoconfiguration($preProcessorClass)
                     ->addTag('joli_media.pre_processor', ['name' => $preProcessorClass])
                 ;
+
+                if (null !== $processTimeout) {
+                    // the pre-processor class must declare a $processTimeout constructor argument
+                    $autoconfiguration->setBindings(['$processTimeout' => $processTimeout]);
+                }
             }
         }
     }
 
-    private function createProcessorServices(ContainerConfigurator $container, array $processorsConfig): void
+    private function createProcessorServices(ContainerConfigurator $container, array $processorsConfig, float $defaultProcessTimeout): void
     {
         $processorContainerService = $container->services()->get('joli_media.processor_container');
 
@@ -1011,6 +1088,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->arg('$cwebpBinary', $processorsConfig['cwebp']['binary'])
                 ->arg('$options', $processorsConfig['cwebp']['options'])
                 ->arg('$identifyBinary', $processorsConfig['cwebp']['identify_binary'])
+                ->arg('$processTimeout', $processorsConfig['cwebp']['process_timeout'] ?? $defaultProcessTimeout)
             ;
 
             $processorContainerService->call('add', ['cwebp', service('.joli_media.processor.cwebp')]);
@@ -1021,6 +1099,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->get('.joli_media.processor.gif2webp')
                 ->arg('$gif2webpBinary', $processorsConfig['gif2webp']['binary'])
                 ->arg('$options', $processorsConfig['gif2webp']['options'])
+                ->arg('$processTimeout', $processorsConfig['gif2webp']['process_timeout'] ?? $defaultProcessTimeout)
             ;
 
             $processorContainerService->call('add', ['gif2webp', service('.joli_media.processor.gif2webp')]);
@@ -1031,6 +1110,7 @@ class JoliMediaBundle extends AbstractBundle
                 ->get('.joli_media.processor.gifsicle')
                 ->arg('$binary', $processorsConfig['gifsicle']['binary'])
                 ->arg('$options', $processorsConfig['gifsicle']['options'])
+                ->arg('$processTimeout', $processorsConfig['gifsicle']['process_timeout'] ?? $defaultProcessTimeout)
             ;
 
             $processorContainerService->call('add', ['gifsicle', service('.joli_media.processor.gifsicle')]);

--- a/src/PostProcessor/AbstractPostProcessor.php
+++ b/src/PostProcessor/AbstractPostProcessor.php
@@ -16,6 +16,7 @@ abstract readonly class AbstractPostProcessor extends AbstractProcessCreator imp
         protected ?string $binary = null,
         protected array $options = [],
         protected ?LoggerInterface $logger = null,
+        protected ?float $processTimeout = null,
     ) {
     }
 
@@ -40,6 +41,11 @@ abstract readonly class AbstractPostProcessor extends AbstractProcessCreator imp
         if (!$this->canProcessFormat($format)) {
             throw new \InvalidArgumentException(\sprintf('The post-processor "%s" cannot process "%s" files. Available formats are: %s', static::class, $format, implode(', ', array_map(static fn (Format $value) => $value->value, $this->getProcessableFormats()))));
         }
+    }
+
+    protected function getProcessTimeout(): ?float
+    {
+        return $this->processTimeout;
     }
 
     protected function isEnabled(): bool

--- a/src/PreProcessor/ExifRemovalPreProcessor.php
+++ b/src/PreProcessor/ExifRemovalPreProcessor.php
@@ -12,6 +12,7 @@ readonly class ExifRemovalPreProcessor extends AbstractPreProcessor implements P
     public function __construct(
         private ?string $exiftoolBinary = '/usr/local/bin/exiftool',
         private ?LoggerInterface $logger = null,
+        private ?float $processTimeout = null,
     ) {
     }
 
@@ -58,5 +59,10 @@ readonly class ExifRemovalPreProcessor extends AbstractPreProcessor implements P
     public function supports(Binary $binary): bool
     {
         return \in_array($binary->getFormat(), [Format::JPEG->value, Format::TIFF->value], true);
+    }
+
+    protected function getProcessTimeout(): ?float
+    {
+        return $this->processTimeout;
     }
 }

--- a/src/Processor/AbstractProcessCreator.php
+++ b/src/Processor/AbstractProcessCreator.php
@@ -13,13 +13,14 @@ abstract readonly class AbstractProcessCreator
     protected function createProcess(array $arguments = [], array $options = []): Process
     {
         $process = new Process($arguments);
+        $timeout = $options['process']['timeout'] ?? $this->getProcessTimeout();
+
+        if (null !== $timeout) {
+            $process->setTimeout((float) $timeout);
+        }
 
         if (!isset($options['process'])) {
             return $process;
-        }
-
-        if (isset($options['process']['timeout'])) {
-            $process->setTimeout($options['process']['timeout']);
         }
 
         if (isset($options['process']['working_directory'])) {
@@ -31,6 +32,15 @@ abstract readonly class AbstractProcessCreator
         }
 
         return $process;
+    }
+
+    /**
+     * The timeout, in seconds, applied to the processes created by createProcess().
+     * Classes that expose a configurable timeout must override this method.
+     */
+    protected function getProcessTimeout(): ?float
+    {
+        return null;
     }
 
     /**

--- a/src/Processor/Cwebp.php
+++ b/src/Processor/Cwebp.php
@@ -37,6 +37,7 @@ readonly class Cwebp extends AbstractProcessor implements ProcessorInterface
         private ?string $identifyBinary = '/usr/bin/identify',
         private array $options = [],
         private ?LoggerInterface $logger = null,
+        private ?float $processTimeout = null,
     ) {
     }
 
@@ -136,6 +137,11 @@ readonly class Cwebp extends AbstractProcessor implements ProcessorInterface
         }
     }
 
+    protected function getProcessTimeout(): ?float
+    {
+        return $this->processTimeout;
+    }
+
     /**
      * @param array<int|string|null> $transformationOptions
      * @param string[]               $processingOptions
@@ -189,7 +195,7 @@ readonly class Cwebp extends AbstractProcessor implements ProcessorInterface
     private function guessIsPhotoFile(string $filename): bool
     {
         // if the image has more than 20k colors, it's likely a photo
-        $process = new Process([$this->identifyBinary, '-format', '%k', $filename]);
+        $process = $this->createProcess([$this->identifyBinary, '-format', '%k', $filename]);
         $process->mustRun();
 
         $output = $process->getOutput();

--- a/src/Processor/Gif2webp.php
+++ b/src/Processor/Gif2webp.php
@@ -26,6 +26,7 @@ readonly class Gif2webp extends AbstractProcessor implements ProcessorInterface
         private ?string $gif2webpBinary = '/usr/local/bin/gif2webp',
         private array $options = [],
         private ?LoggerInterface $logger = null,
+        private ?float $processTimeout = null,
     ) {
     }
 
@@ -122,6 +123,11 @@ readonly class Gif2webp extends AbstractProcessor implements ProcessorInterface
             unlink($outputTemporaryFile);
             unlink($inputTemporaryFile);
         }
+    }
+
+    protected function getProcessTimeout(): ?float
+    {
+        return $this->processTimeout;
     }
 
     /**

--- a/src/Processor/Gifsicle.php
+++ b/src/Processor/Gifsicle.php
@@ -25,6 +25,7 @@ readonly class Gifsicle extends AbstractProcessor implements ProcessorInterface
         private ?string $binary = null,
         private array $options = [],
         private ?LoggerInterface $logger = null,
+        private ?float $processTimeout = null,
     ) {
     }
 
@@ -86,6 +87,11 @@ readonly class Gifsicle extends AbstractProcessor implements ProcessorInterface
             unlink($outputTemporaryFile);
             unlink($inputTemporaryFile);
         }
+    }
+
+    protected function getProcessTimeout(): ?float
+    {
+        return $this->processTimeout;
     }
 
     /**

--- a/tests/src/DependencyInjection/ConfigurationTest.php
+++ b/tests/src/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace JoliCode\MediaBundle\Tests\DependencyInjection;
+
+use JoliCode\MediaBundle\JoliMediaBundle;
+use JoliCode\MediaBundle\PreProcessor\ExifRemovalPreProcessor;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends TestCase
+{
+    public function testDefaultProcessTimeoutConfiguration(): void
+    {
+        $config = $this->processConfiguration([]);
+
+        $this->assertSame(60.0, $config['process_timeout']);
+        $this->assertNull($config['processors']['cwebp']['process_timeout']);
+        $this->assertNull($config['processors']['gif2webp']['process_timeout']);
+        $this->assertNull($config['processors']['gifsicle']['process_timeout']);
+        $this->assertNull($config['post_processors']['gifsicle']['process_timeout']);
+        $this->assertNull($config['post_processors']['jpegoptim']['process_timeout']);
+        $this->assertNull($config['post_processors']['mozjpeg']['process_timeout']);
+        $this->assertNull($config['post_processors']['oxipng']['process_timeout']);
+        $this->assertNull($config['post_processors']['pngquant']['process_timeout']);
+    }
+
+    public function testGlobalProcessTimeoutConfiguration(): void
+    {
+        $config = $this->processConfiguration([
+            [
+                'process_timeout' => 120,
+            ],
+        ]);
+
+        $this->assertSame(120, $config['process_timeout']);
+    }
+
+    public function testProcessorProcessTimeoutConfiguration(): void
+    {
+        $config = $this->processConfiguration([
+            [
+                'processors' => [
+                    'cwebp' => [
+                        'process_timeout' => 120,
+                    ],
+                ],
+                'post_processors' => [
+                    'jpegoptim' => [
+                        'process_timeout' => 0,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(120, $config['processors']['cwebp']['process_timeout']);
+        $this->assertSame(0, $config['post_processors']['jpegoptim']['process_timeout']);
+        $this->assertNull($config['processors']['gif2webp']['process_timeout']);
+    }
+
+    public function testNegativeProcessTimeoutIsRejected(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfiguration([
+            [
+                'process_timeout' => -1,
+            ],
+        ]);
+    }
+
+    public function testPreProcessorsListConfiguration(): void
+    {
+        $config = $this->processConfiguration([
+            [
+                'pre_processors' => [
+                    ExifRemovalPreProcessor::class,
+                ],
+            ],
+        ]);
+
+        $this->assertSame([ExifRemovalPreProcessor::class], array_keys($config['pre_processors']));
+        $this->assertNull($config['pre_processors'][ExifRemovalPreProcessor::class]['process_timeout']);
+    }
+
+    public function testPreProcessorsMapConfiguration(): void
+    {
+        $config = $this->processConfiguration([
+            [
+                'pre_processors' => [
+                    ExifRemovalPreProcessor::class => [
+                        'process_timeout' => 120,
+                    ],
+                    'App\PreProcessor\CustomPreProcessor' => null,
+                ],
+            ],
+        ]);
+
+        $this->assertSame(120, $config['pre_processors'][ExifRemovalPreProcessor::class]['process_timeout']);
+        $this->assertNull($config['pre_processors']['App\PreProcessor\CustomPreProcessor']['process_timeout']);
+    }
+
+    /**
+     * @param array<array<string, mixed>> $configs
+     *
+     * @return array<string, mixed>
+     */
+    private function processConfiguration(array $configs): array
+    {
+        $bundle = new JoliMediaBundle();
+        $treeBuilder = new TreeBuilder('joli_media');
+
+        $configurator = $this->createMock(DefinitionConfigurator::class);
+        $configurator->expects($this->once())
+            ->method('rootNode')
+            ->willReturn($treeBuilder->getRootNode())
+        ;
+
+        $bundle->configure($configurator);
+
+        $processor = new Processor();
+
+        return $processor->process($treeBuilder->buildTree(), $configs);
+    }
+}

--- a/tests/src/Processor/AbstractProcessCreatorTest.php
+++ b/tests/src/Processor/AbstractProcessCreatorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace JoliCode\MediaBundle\Tests\Processor;
+
+use JoliCode\MediaBundle\Processor\AbstractProcessCreator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+class AbstractProcessCreatorTest extends TestCase
+{
+    public function testDefaultTimeoutIsAppliedWhenNotConfigured(): void
+    {
+        $process = (new ProcessCreator())->create(['ls']);
+
+        self::assertSame(60.0, $process->getTimeout());
+    }
+
+    public function testConfiguredTimeoutIsApplied(): void
+    {
+        $process = (new ProcessCreator(120.0))->create(['ls']);
+
+        self::assertSame(120.0, $process->getTimeout());
+    }
+
+    public function testZeroTimeoutDisablesTheTimeout(): void
+    {
+        $process = (new ProcessCreator(0.0))->create(['ls']);
+
+        self::assertNull($process->getTimeout());
+    }
+
+    public function testPerCallTimeoutOverridesTheConfiguredTimeout(): void
+    {
+        $process = (new ProcessCreator(120.0))->create(['ls'], [
+            'process' => [
+                'timeout' => 30,
+            ],
+        ]);
+
+        self::assertSame(30.0, $process->getTimeout());
+    }
+}
+
+readonly class ProcessCreator extends AbstractProcessCreator
+{
+    public function __construct(
+        private ?float $processTimeout = null,
+    ) {
+    }
+
+    /**
+     * @param array<int|string|null> $arguments
+     * @param array<string, mixed>   $options
+     */
+    public function create(array $arguments = [], array $options = []): Process
+    {
+        return $this->createProcess($arguments, $options);
+    }
+
+    protected function getProcessTimeout(): ?float
+    {
+        return $this->processTimeout;
+    }
+}


### PR DESCRIPTION
Add a `process_timeout` configuration directive to control the timeout of the external binary processes.