### PR TITLE
Allow symfony/ux-twig-component 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - feature - The EasyAdmin media library is now browsed through pretty URLs whenever the application uses EasyAdmin pretty URLs - see the [EasyAdmin bridge documentation](doc/bridges/easy-admin.rst)
 - improvement - The admin bridges JavaScript no longer relies on UI classes to find or toggle elements: behavior is hooked on `data-component` attributes, and state on `data-active`, `data-empty`, `data-copied` or the `hidden` attribute
+- improvement - Allow `symfony/ux-twig-component` 3.x in addition to 2.x
 
 ## [0.8.0] - 2026-07-30
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/translation-contracts": "^2.3 || ^3.0",
         "symfony/twig-bridge": "^7.1.9 || ^8.0",
         "symfony/twig-bundle": "^7.0 || ^8.0",
-        "symfony/ux-twig-component": "^2.21",
+        "symfony/ux-twig-component": "^2.21 || ^3.0",
         "symfony/validator": "^7.0 || ^8.0",
         "twig/twig": "^3.20"
     },


### PR DESCRIPTION
Fix #159 
Allows symfony/ux-twig-component 3.x alongside 2.x