### PR TITLE
Allow replacing the binary in PreCreateMediaEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@
 ## [Unreleased]
 
 - feature - The media picked from an EasyAdmin `TextEditorField` toolbar can now be inserted as one of its variations, configured field by field with the new `MediaTextEditorField`, or for the whole project with the `joli_media_easy_admin.text_editor.variation` directive - see the [EasyAdmin bridge documentation](doc/bridges/easy-admin.rst)
+- feature - The `binary` property of the `PreCreateMediaEvent` is now writable, so that a listener can sanitize or replace an uploaded content before it is stored - see the [events documentation](doc/misc-features/events.rst)
 - feature - The EasyAdmin media library is now browsed through pretty URLs whenever the application uses EasyAdmin pretty URLs - see the [EasyAdmin bridge documentation](doc/bridges/easy-admin.rst)
 - improvement - The admin bridges JavaScript no longer relies on UI classes to find or toggle elements: behavior is hooked on `data-component` attributes, and state on `data-active`, `data-empty`, `data-copied` or the `hidden` attribute
 - improvement - Allow `symfony/ux-twig-component` 3.x in addition to 2.x
+- improvement - Add a `Binary::withContent()` method, which builds a copy of a binary holding a different content
+- fix - Creating a media inside the trash directory now throws a `ForbiddenPathException`, consistently with the folder creation, move and deletion APIs
 - fix - `Media` objects are now correctly restored when unserialized, for instance when they are read from the Doctrine second level cache
 - fix - The EasyAdmin media selector widget is now rendered when the `MediaChoiceType` is used outside of a `MediaChoiceField`, for instance when it is nested into another form type such as the A2lix `TranslationsType` - see the [EasyAdmin bridge documentation](doc/bridges/easy-admin.rst)
 

--- a/demo/application/src/Media/EventListener/StripExifMetadataListener.php
+++ b/demo/application/src/Media/EventListener/StripExifMetadataListener.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Media\EventListener;
+
+use JoliCode\MediaBundle\Event\MediaEvents;
+use JoliCode\MediaBundle\Event\PreCreateMediaEvent;
+use JoliCode\MediaBundle\Model\Format;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Process\Process;
+
+/**
+ * Strips the metadata of the uploaded images before they are stored as originals.
+ *
+ * The bundle ships an ExifRemovalPreProcessor, but pre-processors only run in the
+ * variation pipeline: the originals keep their metadata, GPS coordinates included.
+ * This listener sanitizes the original itself, before it is written to the storage.
+ *
+ * Note that it uses "-all=" and not the "-ifd1:all=" of the ExifRemovalPreProcessor,
+ * which only clears the thumbnail IFD.
+ */
+final readonly class StripExifMetadataListener
+{
+    public function __construct(
+        #[Autowire('%joli_media.binary.exiftool%')]
+        private string $exiftoolBinary,
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    #[AsEventListener(event: MediaEvents::PRE_CREATE_MEDIA)]
+    public function onPreCreateMedia(PreCreateMediaEvent $event): void
+    {
+        if (!\in_array($event->binary->getFormat(), [Format::JPEG->value, Format::TIFF->value], true)) {
+            return;
+        }
+
+        $temporaryFile = tempnam(sys_get_temp_dir(), 'media');
+
+        if (false === $temporaryFile) {
+            throw new \RuntimeException('Unable to create a temporary file.');
+        }
+
+        file_put_contents($temporaryFile, $event->binary->getContent());
+
+        try {
+            $process = new Process([
+                $this->exiftoolBinary,
+                '-all=',
+                '-m',
+                '-overwrite_original',
+                $temporaryFile,
+            ]);
+            // an exception thrown here aborts the media creation, before anything is
+            // written to the storage: better to reject the upload than to store a
+            // media which still carries its GPS coordinates
+            $process->mustRun();
+
+            $content = file_get_contents($temporaryFile);
+
+            if (false === $content) {
+                throw new \RuntimeException(\sprintf('Unable to read the content of the temporary file "%s".', $temporaryFile));
+            }
+
+            $this->logger?->info('Stripped the metadata of an uploaded media', [
+                'path' => $event->path,
+                'original size' => $event->binary->getContentSize(),
+                'sanitized size' => \strlen($content),
+            ]);
+
+            $event->binary = $event->binary->withContent($content);
+        } finally {
+            unlink($temporaryFile);
+        }
+    }
+}

--- a/doc/misc-features/events.rst
+++ b/doc/misc-features/events.rst
@@ -8,10 +8,12 @@ Available Events
 
 Media Events are triggered when media objects are created or deleted:
 
-- ``PreCreateMediaEvent``: Triggered before a media object is created. Example usage: Validate or modify the media content before it is saved.
+- ``PreCreateMediaEvent``: Triggered before a media object is created. Example usage: Reject an upload, or replace its content before it is written to the storage - see `Sanitizing a Media Before It Is Stored`_.
 - ``PostCreateMediaEvent``: Triggered after a media object is created. Example usage: Perform additional actions, such as logging or notifying other services.
 - ``PreDeleteMediaEvent``: Triggered before a media object is deleted. Example usage: Check if the media is in use or prevent deletion under certain conditions.
 - ``PostDeleteMediaEvent``: Triggered after a media object is deleted. Example usage: Clean up related resources or notify other parts of the application.
+- ``PreMoveMediaEvent``: Triggered before a media object is moved or renamed. Example usage: Prevent the move under certain conditions.
+- ``PostMoveMediaEvent``: Triggered after a media object is moved or renamed. Example usage: Update the references to the media in the application. If a listener throws an exception, the move is rolled back.
 
 Folder Events are triggered when folders are created or deleted:
 
@@ -19,6 +21,8 @@ Folder Events are triggered when folders are created or deleted:
 - ``PostCreateFolderEvent``: Triggered after a folder is created. Example usage: Log the creation or notify other services.
 - ``PreDeleteFolderEvent``: Triggered before a folder is deleted. Example usage: Check if the folder is empty or prevent deletion under certain conditions.
 - ``PostDeleteFolderEvent``: Triggered after a folder is deleted. Example usage: Clean up related resources or notify other parts of the application.
+- ``PreMoveFolderEvent``: Triggered before a folder is moved or renamed. Example usage: Prevent the move under certain conditions.
+- ``PostMoveFolderEvent``: Triggered after a folder is moved or renamed. Example usage: Update the references to the medias it holds. If a listener throws an exception, the move is rolled back.
 
 The ``PreResolveMediaEvent`` is triggered before a media object is resolved. This event allows you to modify the media path or perform additional checks before the media is accessed.
 
@@ -74,3 +78,62 @@ When resolving a media, the ``PreResolveMediaEvent`` can be used to modify the m
             }
         }
     }
+
+Sanitizing a Media Before It Is Stored
+--------------------------------------
+
+The ``PreCreateMediaEvent`` is dispatched by the ``OriginalStorage`` before anything is written to the storage, and its ``binary`` property is writable. A listener can therefore replace the content which is about to be stored, and the storage will write the replacement instead of the uploaded content - without any additional read or write.
+
+A typical use case is stripping the metadata of the uploaded images: the ``ExifRemovalPreProcessor`` shipped by the bundle only runs in the variation pipeline, so the originals keep their metadata, GPS coordinates included. The following listener sanitizes the original itself::
+
+    namespace App\EventListener;
+
+    use JoliCode\MediaBundle\Event\MediaEvents;
+    use JoliCode\MediaBundle\Event\PreCreateMediaEvent;
+    use JoliCode\MediaBundle\Model\Format;
+    use Symfony\Component\DependencyInjection\Attribute\Autowire;
+    use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+    use Symfony\Component\Process\Process;
+
+    final readonly class StripExifMetadataListener
+    {
+        public function __construct(
+            #[Autowire('%joli_media.binary.exiftool%')]
+            private string $exiftoolBinary,
+        ) {
+        }
+
+        #[AsEventListener(event: MediaEvents::PRE_CREATE_MEDIA)]
+        public function onPreCreateMedia(PreCreateMediaEvent $event): void
+        {
+            if (!in_array($event->binary->getFormat(), [Format::JPEG->value, Format::TIFF->value], true)) {
+                return;
+            }
+
+            $temporaryFile = tempnam(sys_get_temp_dir(), 'media');
+            file_put_contents($temporaryFile, $event->binary->getContent());
+
+            try {
+                (new Process([$this->exiftoolBinary, '-all=', '-m', '-overwrite_original', $temporaryFile]))->mustRun();
+                $event->binary = $event->binary->withContent(file_get_contents($temporaryFile));
+            } finally {
+                unlink($temporaryFile);
+            }
+        }
+    }
+
+A working version of this listener is part of `the demo application <../getting-started/demo.rst>`_.
+
+The ``Binary::withContent()`` method builds a copy of the binary holding a different content, and preserving its mime type and format. When the replacement is of another nature, build a new ``Binary`` instead.
+
+.. note::
+
+    The listener is called before anything is written: throwing an exception aborts the creation of the media, and nothing is stored. This is the recommended way to reject an upload which does not satisfy the rules of the application.
+
+.. caution::
+
+    The ``path`` property of the event is read-only, and the storage writes the replacement under the very same path. **A listener must therefore preserve the format of the binary**, otherwise the stored file would carry a misleading extension - and the mime type reported for it afterwards, which most storages derive from the extension, would be wrong.
+
+    Conversions which change the format, such as turning a RAW or HEIC upload into a JPEG, must be performed by the caller before ``createMedia()`` is called, so that the target path can carry the right extension.
+
+Finally, note that the mime type served to the clients is computed from the *stored file*, and not from the mime type declared by the binary: a listener cannot alter the ``Content-Type`` of the responses.

--- a/src/Binary/Binary.php
+++ b/src/Binary/Binary.php
@@ -110,4 +110,20 @@ class Binary
 
         return $dimensions['height'] ?? null;
     }
+
+    /**
+     * Builds a copy of this binary, holding a different content.
+     *
+     * The mime type, format and path are preserved, but the pixel dimensions are
+     * not: they are guessed again from the new content, when they are needed.
+     */
+    public function withContent(string $content): self
+    {
+        return new self(
+            $this->mimeType,
+            $this->format,
+            $content,
+            $this->path,
+        );
+    }
 }

--- a/src/Event/PreCreateMediaEvent.php
+++ b/src/Event/PreCreateMediaEvent.php
@@ -10,7 +10,7 @@ final class PreCreateMediaEvent extends MediaEvent
     public function __construct(
         public readonly OriginalStorage $originalStorage,
         public readonly string $path,
-        public readonly Binary $binary,
+        public Binary $binary,
     ) {
     }
 }

--- a/src/Model/Media.php
+++ b/src/Model/Media.php
@@ -241,7 +241,8 @@ class Media implements StorableInterface
             throw new \RuntimeException('No binary set to store');
         }
 
-        $this->storage->createMediaFromBinary($this->path, $this->binary);
+        // the pre-create listeners may have replaced the binary, so adopt the stored one
+        $this->binary = $this->storage->createMediaFromBinary($this->path, $this->binary)->getBinary();
         $this->stored = true;
     }
 

--- a/src/PreProcessor/ExifRemovalPreProcessor.php
+++ b/src/PreProcessor/ExifRemovalPreProcessor.php
@@ -42,9 +42,7 @@ readonly class ExifRemovalPreProcessor extends AbstractPreProcessor implements P
                 'processed size' => filesize($temporaryFile),
             ]);
 
-            return new Binary(
-                $binary->getMimeType(),
-                $binary->getFormat(),
+            return $binary->withContent(
                 file_get_contents($temporaryFile) ?: throw new \RuntimeException(\sprintf('Failed to read content from temporary file "%s"', $temporaryFile)),
             );
         } catch (\Exception $exception) {

--- a/src/Storage/OriginalStorage.php
+++ b/src/Storage/OriginalStorage.php
@@ -92,6 +92,10 @@ class OriginalStorage
     {
         $path = Resolver::normalizePath($path);
 
+        if ($this->trashPath === $path || str_starts_with($path, $this->trashPath . '/')) {
+            throw new ForbiddenPathException($this->trashPath);
+        }
+
         if ($this->dispatcher->hasListeners(MediaEvents::PRE_CREATE_MEDIA)) {
             $event = new PreCreateMediaEvent($this, $path, $binary);
             $this->dispatcher->dispatch($event, MediaEvents::PRE_CREATE_MEDIA);

--- a/src/Storage/OriginalStorage.php
+++ b/src/Storage/OriginalStorage.php
@@ -95,6 +95,7 @@ class OriginalStorage
         if ($this->dispatcher->hasListeners(MediaEvents::PRE_CREATE_MEDIA)) {
             $event = new PreCreateMediaEvent($this, $path, $binary);
             $this->dispatcher->dispatch($event, MediaEvents::PRE_CREATE_MEDIA);
+            $binary = $event->binary;
         }
 
         $this->getLibrary()->deleteAllVariations($path);

--- a/tests/src/BaseTestCase.php
+++ b/tests/src/BaseTestCase.php
@@ -25,7 +25,7 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Mime\FileBinaryMimeTypeGuesser;
 use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Routing\Generator\UrlGenerator;
@@ -63,6 +63,8 @@ class BaseTestCase extends WebTestCase
     ];
 
     protected CacheStorage $cacheStorage;
+
+    protected EventDispatcher $eventDispatcher;
 
     protected Converter $converter;
 
@@ -206,7 +208,8 @@ class BaseTestCase extends WebTestCase
         string $urlPath,
         UrlGeneratorInterface $urlGenerator,
     ): OriginalStorage {
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        // every storage of a test case shares the same dispatcher, as they would in an application
+        $this->eventDispatcher ??= new EventDispatcher();
         $cache = $this->createMock(CacheInterface::class);
         $cache->method('get')->willReturnCallback(function (string $key, callable $callback) {
             $item = $this->createMock(ItemInterface::class);
@@ -232,7 +235,7 @@ class BaseTestCase extends WebTestCase
             '.trash',
             $urlGenerator,
             $mimeTypeGuesser,
-            $eventDispatcher,
+            $this->eventDispatcher,
             $mediaPropertyAccessor,
         );
     }

--- a/tests/src/Binary/BinaryTest.php
+++ b/tests/src/Binary/BinaryTest.php
@@ -64,4 +64,41 @@ class BinaryTest extends BaseTestCase
         $binary = new Binary('image/jpeg', Format::JPEG->value, $content);
         $this->assertSame(Format::JPEG->value, $binary->getFormat());
     }
+
+    public function testBinaryWithContent(): void
+    {
+        $content = BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH);
+        $binary = new Binary('image/png', Format::PNG->value, $content, 'some/path.png');
+
+        $copy = $binary->withContent('replaced content');
+
+        $this->assertNotSame($binary, $copy);
+        $this->assertSame('replaced content', $copy->getContent());
+        $this->assertSame(\strlen('replaced content'), $copy->getContentSize());
+        $this->assertSame('image/png', $copy->getMimeType());
+        $this->assertSame(Format::PNG->value, $copy->getFormat());
+        $this->assertSame('some/path.png', $copy->getPath());
+
+        // the original binary is left untouched
+        $this->assertSame($content, $binary->getContent());
+    }
+
+    public function testBinaryWithContentDoesNotCarryThePixelDimensionsOver(): void
+    {
+        $binary = new Binary(
+            'image/png',
+            Format::PNG->value,
+            BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH),
+            null,
+            2560,
+            1920,
+        );
+
+        // the dimensions are guessed again from the new content
+        $this->assertFalse($binary->withContent('')->getPixelDimensions());
+        $this->assertSame(
+            ['height' => 1920, 'width' => 2560],
+            $binary->withContent(BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH))->getPixelDimensions(),
+        );
+    }
 }

--- a/tests/src/Event/Listener/CreateMediaEventListenerTest.php
+++ b/tests/src/Event/Listener/CreateMediaEventListenerTest.php
@@ -74,13 +74,12 @@ class CreateMediaEventListenerTest extends WebTestCase
         $path = self::TEST_FOLDER . '/rejected.txt';
 
         try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('This media is not acceptable');
             $this->originalStorage->createMediaFromBinary($path, new Binary('text/plain', 'txt', 'sensitive content'));
-            $this->fail('The exception thrown by the listener should not have been swallowed.');
-        } catch (\RuntimeException $e) {
-            $this->assertSame('This media is not acceptable', $e->getMessage());
+        } finally {
+            $this->assertFalse($this->originalStorage->has($path), 'Nothing should have been written to the storage.');
         }
-
-        $this->assertFalse($this->originalStorage->has($path), 'Nothing should have been written to the storage.');
     }
 
     protected static function getKernelClass(): string

--- a/tests/src/Event/Listener/CreateMediaEventListenerTest.php
+++ b/tests/src/Event/Listener/CreateMediaEventListenerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace JoliCode\MediaBundle\Tests\Event\Listener;
+
+use JoliCode\MediaBundle\Binary\Binary;
+use JoliCode\MediaBundle\Event\MediaEvents;
+use JoliCode\MediaBundle\Event\PreCreateMediaEvent;
+use JoliCode\MediaBundle\Library\LibraryContainer;
+use JoliCode\MediaBundle\Storage\OriginalStorage;
+use JoliCode\MediaBundle\Tests\Application\Kernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class CreateMediaEventListenerTest extends WebTestCase
+{
+    private const TEST_FOLDER = 'pre-create-media-event';
+
+    private EventDispatcherInterface $eventDispatcher;
+
+    private OriginalStorage $originalStorage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $container = static::getContainer();
+
+        /** @var LibraryContainer */
+        $libraries = $container->get('joli_media.library_container');
+        $this->originalStorage = $libraries->get('default')->getOriginalStorage();
+
+        /** @var EventDispatcherInterface */
+        $eventDispatcher = $container->get('event_dispatcher');
+        $this->eventDispatcher = $eventDispatcher;
+
+        if ($this->originalStorage->hasDirectory(self::TEST_FOLDER)) {
+            $this->originalStorage->deleteDirectory(self::TEST_FOLDER);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalStorage->hasDirectory(self::TEST_FOLDER)) {
+            $this->originalStorage->deleteDirectory(self::TEST_FOLDER);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testAListenerCanReplaceTheBinaryOfACreatedMedia(): void
+    {
+        $this->eventDispatcher->addListener(
+            MediaEvents::PRE_CREATE_MEDIA,
+            static function (PreCreateMediaEvent $event): void {
+                $event->binary = $event->binary->withContent(strtoupper($event->binary->getContent()));
+            },
+        );
+
+        $path = self::TEST_FOLDER . '/replaced.txt';
+        $media = $this->originalStorage->createMedia($path, 'sensitive content');
+
+        $this->assertSame('SENSITIVE CONTENT', $media->getBinary()->getContent());
+        $this->assertSame('SENSITIVE CONTENT', $this->originalStorage->get($path)->getContent());
+    }
+
+    public function testAListenerCanRejectACreatedMediaByThrowing(): void
+    {
+        $this->eventDispatcher->addListener(
+            MediaEvents::PRE_CREATE_MEDIA,
+            static function (PreCreateMediaEvent $event): void {
+                throw new \RuntimeException('This media is not acceptable');
+            },
+        );
+
+        $path = self::TEST_FOLDER . '/rejected.txt';
+
+        try {
+            $this->originalStorage->createMediaFromBinary($path, new Binary('text/plain', 'txt', 'sensitive content'));
+            $this->fail('The exception thrown by the listener should not have been swallowed.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('This media is not acceptable', $e->getMessage());
+        }
+
+        $this->assertFalse($this->originalStorage->has($path), 'Nothing should have been written to the storage.');
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+}

--- a/tests/src/Storage/OriginalStorageTest.php
+++ b/tests/src/Storage/OriginalStorageTest.php
@@ -3,6 +3,8 @@
 namespace JoliCode\MediaBundle\Tests\Storage;
 
 use JoliCode\MediaBundle\Binary\Binary;
+use JoliCode\MediaBundle\Event\MediaEvents;
+use JoliCode\MediaBundle\Event\PreCreateMediaEvent;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
 use JoliCode\MediaBundle\Tests\BaseTestCase;
@@ -35,6 +37,100 @@ class OriginalStorageTest extends BaseTestCase
         $this->assertSame($path, $media->getPath());
         $this->assertTrue($this->originalFilesystem->fileExists($path));
         $this->assertSame(BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH), $this->originalFilesystem->read($path));
+    }
+
+    public function testCreateMediaWithABinaryReplacedByAListener(): void
+    {
+        $this->eventDispatcher->addListener(
+            MediaEvents::PRE_CREATE_MEDIA,
+            static function (PreCreateMediaEvent $event): void {
+                $event->binary = $event->binary->withContent('sanitized content');
+            },
+        );
+
+        $path = 'test.png';
+        $media = $this->originalStorage->createMedia($path, BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH));
+
+        $this->assertSame('sanitized content', $this->originalFilesystem->read($path));
+        $this->assertSame('sanitized content', $media->getBinary()->getContent());
+        // the replacement keeps the mime type and format guessed from the uploaded content
+        $this->assertSame('image/png', $media->getBinary()->getMimeType());
+    }
+
+    public function testCreateMediaFromBinaryWithABinaryReplacedByAListener(): void
+    {
+        $this->eventDispatcher->addListener(
+            MediaEvents::PRE_CREATE_MEDIA,
+            static function (PreCreateMediaEvent $event): void {
+                $event->binary = $event->binary->withContent('sanitized content');
+            },
+        );
+
+        $path = 'test.png';
+        $binary = new Binary('image/png', Format::PNG->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH));
+        $media = $this->originalStorage->createMediaFromBinary($path, $binary);
+
+        $this->assertSame('sanitized content', $this->originalFilesystem->read($path));
+        $this->assertSame('sanitized content', $media->getBinary()->getContent());
+    }
+
+    public function testCreateMediaFromBinaryWithAListenerLeavingTheBinaryUntouched(): void
+    {
+        $seen = null;
+        $this->eventDispatcher->addListener(
+            MediaEvents::PRE_CREATE_MEDIA,
+            static function (PreCreateMediaEvent $event) use (&$seen): void {
+                $seen = $event->path;
+            },
+        );
+
+        $path = 'test.png';
+        $content = BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH);
+        $media = $this->originalStorage->createMediaFromBinary($path, new Binary('image/png', Format::PNG->value, $content));
+
+        $this->assertSame($path, $seen);
+        $this->assertSame($content, $this->originalFilesystem->read($path));
+        $this->assertSame($content, $media->getBinary()->getContent());
+    }
+
+    public function testCreateMediaFromBinaryIsAbortedWhenAListenerThrows(): void
+    {
+        $this->eventDispatcher->addListener(
+            MediaEvents::PRE_CREATE_MEDIA,
+            static function (PreCreateMediaEvent $event): void {
+                throw new \RuntimeException('This media is not acceptable');
+            },
+        );
+
+        $path = 'test.png';
+        $binary = new Binary('image/png', Format::PNG->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH));
+
+        try {
+            $this->originalStorage->createMediaFromBinary($path, $binary);
+            $this->fail('The exception thrown by the listener should not have been swallowed.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('This media is not acceptable', $e->getMessage());
+        }
+
+        $this->assertFalse($this->originalFilesystem->fileExists($path), 'Nothing should have been written to the storage.');
+    }
+
+    public function testStoreAdoptsTheBinaryReplacedByAListener(): void
+    {
+        $this->eventDispatcher->addListener(
+            MediaEvents::PRE_CREATE_MEDIA,
+            static function (PreCreateMediaEvent $event): void {
+                $event->binary = $event->binary->withContent('sanitized content');
+            },
+        );
+
+        $path = 'test.png';
+        $binary = new Binary('image/png', Format::PNG->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH));
+        $media = new Media($path, $this->originalStorage, $binary);
+        $media->store();
+
+        $this->assertSame('sanitized content', $this->originalFilesystem->read($path));
+        $this->assertSame('sanitized content', $media->getBinary()->getContent());
     }
 
     public function testGetBinary(): void

--- a/tests/src/Storage/OriginalStorageTest.php
+++ b/tests/src/Storage/OriginalStorageTest.php
@@ -5,9 +5,11 @@ namespace JoliCode\MediaBundle\Tests\Storage;
 use JoliCode\MediaBundle\Binary\Binary;
 use JoliCode\MediaBundle\Event\MediaEvents;
 use JoliCode\MediaBundle\Event\PreCreateMediaEvent;
+use JoliCode\MediaBundle\Exception\ForbiddenPathException;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
 use JoliCode\MediaBundle\Tests\BaseTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class OriginalStorageTest extends BaseTestCase
 {
@@ -131,6 +133,30 @@ class OriginalStorageTest extends BaseTestCase
 
         $this->assertSame('sanitized content', $this->originalFilesystem->read($path));
         $this->assertSame('sanitized content', $media->getBinary()->getContent());
+    }
+
+    #[DataProvider('provideForbiddenTrashPaths')]
+    public function testCreateMediaInTheTrashDirectoryIsForbidden(string $path): void
+    {
+        $this->expectException(ForbiddenPathException::class);
+        $this->expectExceptionMessage('The path ".trash" is reserved.');
+
+        try {
+            $this->originalStorage->createMedia($path, BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH));
+        } finally {
+            $this->assertFalse($this->originalFilesystem->fileExists($path));
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideForbiddenTrashPaths(): iterable
+    {
+        yield 'the trash directory itself' => ['.trash'];
+        yield 'a file in the trash directory' => ['.trash/test.png'];
+        yield 'a file in a subfolder of the trash directory' => ['.trash/sub/folder/test.png'];
+        yield 'a non normalized path' => ['/.trash/test.png'];
     }
 
     public function testGetBinary(): void

--- a/tests/src/Storage/OriginalStorageTest.php
+++ b/tests/src/Storage/OriginalStorageTest.php
@@ -108,13 +108,12 @@ class OriginalStorageTest extends BaseTestCase
         $binary = new Binary('image/png', Format::PNG->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::PNG_FIXTURE_PATH));
 
         try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('This media is not acceptable');
             $this->originalStorage->createMediaFromBinary($path, $binary);
-            $this->fail('The exception thrown by the listener should not have been swallowed.');
-        } catch (\RuntimeException $e) {
-            $this->assertSame('This media is not acceptable', $e->getMessage());
+        } finally {
+            $this->assertFalse($this->originalFilesystem->fileExists($path), 'Nothing should have been written to the storage.');
         }
-
-        $this->assertFalse($this->originalFilesystem->fileExists($path), 'Nothing should have been written to the storage.');
     }
 
     public function testStoreAdoptsTheBinaryReplacedByAListener(): void


### PR DESCRIPTION
fix #138

This PR makes it possible to replace the binary in a `PreCreateMediaEvent`, so we can replace the content of a Media before it is written to storage.