### PR TITLE
Move convert to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- fix - `Variation::cloneWithOutputFormat()` no longer drops the pixel-ratio multiplier of the variation it clones
 - improvement - The `trash_path` configuration directive is now normalized and validated at configuration time
 - improvement - `OriginalStorage::listDirectories()`, `listFiles()`, `listMedias()` and `listMediasPaginated()` now hide the trash directory and all of its contents
 - improvement - Add `OriginalStorage::isTrashPath()` and `OriginalStorage::assertPathIsNotTrash()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+- feature - The `must_store_when_generating_url` setting can now be defined per variation, overriding the library-level `cache` setting - see the [variations documentation](doc/variations/variations.rst)
+- improvement - The "generate the variation file when its URL is generated" behavior moved from the Twig layer into `MediaVariation::getUrl()` itself: every URL generation (Twig components and filters, admin bridges, or custom code such as an API Platform normalizer) now honors the `must_store_when_generating_url` setting - see the [URL generation documentation](doc/misc-features/url-generation.rst)
+- bc break - The `JoliMediaExtension`, `Img` and `Source` constructors no longer take a `Converter` argument
+- bc break - The extra `srcset` variations of the `joli:Img` component are no longer generated unconditionally when the component is rendered: they now follow the `must_store_when_generating_url` setting, like every other variation. Enable the setting (at the library or variation level), or pre-generate the variations with the `joli:media:convert` command, to keep the previous markup
+- bc break - A failing conversion no longer removes the corresponding candidate from the `srcset` of the `joli:Source` component: the URL is now always output, and the variation is served on the fly when requested
 - fix - `Variation::cloneWithOutputFormat()` no longer drops the pixel-ratio multiplier of the variation it clones
 - improvement - The `trash_path` configuration directive is now normalized and validated at configuration time
 - improvement - `OriginalStorage::listDirectories()`, `listFiles()`, `listMedias()` and `listMediasPaginated()` now hide the trash directory and all of its contents

--- a/config/services.php
+++ b/config/services.php
@@ -459,13 +459,11 @@ return static function (ContainerConfigurator $container): void {
         ->set('joli_media.twig_extension', JoliMediaExtension::class)
         ->args([
             service('joli_media.resolver'),
-            service('joli_media.converter'),
         ])
         ->tag('twig.extension')
 
         ->set('joli_media.twig.component.img', Img::class)
         ->args([
-            '$converter' => service('joli_media.converter'),
             '$resolver' => service('joli_media.resolver'),
             '$libraries' => service('joli_media.library_container'),
             '$logger' => service('logger')->ignoreOnInvalid(),
@@ -481,7 +479,6 @@ return static function (ContainerConfigurator $container): void {
 
         ->set('joli_media.twig.component.source', Source::class)
         ->args([
-            '$converter' => service('joli_media.converter'),
             '$resolver' => service('joli_media.resolver'),
             '$logger' => service('logger')->ignoreOnInvalid(),
         ])
@@ -513,6 +510,7 @@ return static function (ContainerConfigurator $container): void {
             '$postProcessorsConfiguration' => abstract_arg('post_processors_configuration'),
             '$voters' => abstract_arg('joli_media.voters'),
             '$multiplier' => abstract_arg('multiplier'),
+            '$mustStoreWhenGeneratingUrl' => abstract_arg('mustStoreWhenGeneratingUrl'),
         ])
 
         // voter

--- a/doc/getting-started/configuration.rst
+++ b/doc/getting-started/configuration.rst
@@ -38,7 +38,7 @@ A library is defined by a name and contains the multiple information:
 
   - the ``flysystem`` key contains the id of a Flysystem service that addresses the location where cache media are stored.
   - its ``url_generator``: the configuration of the way URLs should be generated for the media variations
-  - ``must_store_when_generating_url`` is a boolean (default: ``false``) that defines whether the media variation must be generated and stored when its URL is generated. If set to ``false``, the media variation will be generated on-the-fly when accessed for the first time.
+  - ``must_store_when_generating_url`` is a boolean (default: ``false``) that defines whether the media variation must be generated and stored when its URL is generated. If set to ``false``, the media variation will be generated on-the-fly when accessed for the first time. This setting can be overridden for a single variation, using the ``must_store_when_generating_url`` attribute of the variation configuration - the variations that leave it to ``null`` (the default) fall back to this library-level value. Variation clones (the ``@2x`` pixel-ratio variations and the automatic WebP alternatives) inherit the value of the variation they are cloned from.
 
 - ``variations`` that can be created from the original media. See the `Variation configuration <../variations/variations.rst>`_ section for more information
 - ``enable_auto_webp`` is a boolean (default: ``false``) that enables the automatic generation of WebP variations for the media. When enabled, the configured variations in the ``variations`` above node will be duplicated in WebP format, in addition to the original format.

--- a/doc/misc-features/twig-components.rst
+++ b/doc/misc-features/twig-components.rst
@@ -545,3 +545,7 @@ This could be a problem if you are picky about the HTML attributes or if you do 
             default:
                 cache:
                     must_store_when_generating_url: true
+
+This behavior is not specific to the Twig components: it is implemented by ``MediaVariation::getUrl()`` itself, so *any* URL generation for a media variation (the Twig components and filters, the admin bridges, or your own code - for instance an API Platform normalizer) generates and stores the missing variation file when the setting is enabled. See the `URL generation documentation <url-generation.rst>`_ for more details.
+
+The setting can also be overridden for a single variation, using the ``must_store_when_generating_url`` attribute of the variation configuration - see the `Variations documentation <../variations/variations.rst>`_.

--- a/doc/misc-features/url-generation.rst
+++ b/doc/misc-features/url-generation.rst
@@ -34,6 +34,15 @@ There are few chances that you need to instanciate the ``Media`` or ``MediaVaria
         $media = $resolver->resolve('example-image.png');
         $mediaVariation = $resolver->resolve('example-image.png', null, 'variation_name');
 
+Generating the variation file along with its URL
+------------------------------------------------
+
+By default, generating the URL of a media variation does not generate the variation file itself - it is generated on the fly, the first time the URL is requested. If the ``must_store_when_generating_url`` setting is enabled (either in the library's ``cache`` configuration or on the variation itself - see the `Configuration documentation <../getting-started/configuration.rst>`_), ``MediaVariation::getUrl()`` generates and stores the missing variation file before returning the URL.
+
+Since this behavior is implemented by ``MediaVariation::getUrl()`` itself, it applies everywhere a variation URL is generated: in the Twig components and filters, in the admin bridges, or in your own code - for instance in an API Platform normalizer.
+
+Note that a conversion failure never makes ``getUrl()`` throw: the error is logged as a warning, and the URL is returned anyway (the ``MediaController`` will then try to generate the variation on the fly when the URL is requested).
+
 Twig extension
 --------------
 

--- a/doc/variations/variations.rst
+++ b/doc/variations/variations.rst
@@ -50,6 +50,29 @@ This is a string that defines the format of the variation. If not set, the origi
 
     There are chances that, for compatibility reasons, you want to keep the original image format. In this case, you can omit the ``format`` key in the variation configuration. If you wish to generate variations both in the original format and in WebP format, you can define two variations with the same transformers, one without the ``format`` key, and one with the ``format`` key set to ``webp``. A better alternative, however, is to use the ``enable_auto_webp`` configuration directive above, which will automatically generate an additional WebP variation.
 
+must_store_when_generating_url
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is a boolean that defines whether the variation file must be generated and stored when its URL is generated - see the `URL generation documentation <../misc-features/url-generation.rst>`_.
+
+If not defined (or set to ``null``), the value of the ``must_store_when_generating_url`` option defined in the library ``cache`` configuration is used instead. Setting it explicitly to ``true`` or ``false`` overrides the library-level value for this variation only. The variation clones (the ``@2x`` pixel-ratio variations and the automatic WebP alternatives) inherit the value of the variation they are cloned from.
+
+.. code-block:: yaml
+
+    joli_media:
+        libraries:
+            default:
+                cache:
+                    # ...
+                    must_store_when_generating_url: false
+                variations:
+                    thumbnail:
+                        # this variation is generated as soon as its URL is generated,
+                        # even though the library does not enable the setting
+                        must_store_when_generating_url: true
+                        transformers:
+                            # ...
+
 pixel_ratios
 ~~~~~~~~~~~~
 

--- a/src/Conversion/Converter.php
+++ b/src/Conversion/Converter.php
@@ -2,7 +2,6 @@
 
 namespace JoliCode\MediaBundle\Conversion;
 
-use JoliCode\MediaBundle\Exception\UnprocessableMediaException;
 use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
@@ -83,8 +82,8 @@ readonly class Converter
         if ($mediaVariation->getStorage()->mustStoreWhenGeneratingUrl($mediaVariation)) {
             try {
                 $this->convertMediaVariation($mediaVariation, false);
-            } catch (UnprocessableMediaException $e) {
-                // do not make URL generation (a rendering concern) fatal for unprocessable medias
+            } catch (\Exception $e) {
+                // conversion failures must never make URL generation fatal
                 $this->logger?->warning($e->getMessage(), ['exception' => $e]);
             }
         }

--- a/src/Inspector/TransformationDataHolder.php
+++ b/src/Inspector/TransformationDataHolder.php
@@ -43,7 +43,12 @@ class TransformationDataHolder
         }
 
         $key = $this->getKey($mediaVariation);
-        $this->data[$key]['url'] = $mediaVariation->getUrl();
+        // build the URL through the storage to avoid triggering a nested
+        // conversion: complete() runs before the variation binary is stored
+        $this->data[$key]['url'] = $mediaVariation->getStorage()->getUrl(
+            $mediaVariation->getMedia()->getPath(),
+            $mediaVariation->getVariation(),
+        );
         $this->data[$key]['duration'] = $this->getStopWatchEvent()?->getDuration();
 
         if ('image' === $this->data[$key]['fileType']) {

--- a/src/JoliMediaBundle.php
+++ b/src/JoliMediaBundle.php
@@ -15,6 +15,7 @@ use JoliCode\MediaBundle\Doctrine\Type\MediaType;
 use JoliCode\MediaBundle\Doctrine\Types;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
+use JoliCode\MediaBundle\Model\MediaVariation;
 use JoliCode\MediaBundle\PreProcessor\HeifPreProcessor;
 use JoliCode\MediaBundle\Processor\Imagine;
 use JoliCode\MediaBundle\Resolver\Resolver;
@@ -39,6 +40,7 @@ class JoliMediaBundle extends AbstractBundle
         // media unserialization does not depend on Doctrine: this must be set
         // before the Doctrine check below
         Media::$libraryContainerInitializer = fn (): ?object => $this->container->get('joli_media.library_container');
+        MediaVariation::$converterInitializer = fn (): ?object => $this->container->get('joli_media.converter');
 
         if (!class_exists(StringType::class)) {
             return;
@@ -261,6 +263,10 @@ class JoliMediaBundle extends AbstractBundle
                     ->scalarNode('format')->end()
                     ->booleanNode('enable_auto_webp')
                         ->info('If true and the format config attribute is not set or different from "webp", enables an additionnal webp version of the variation.')
+                    ->end()
+                    ->booleanNode('must_store_when_generating_url')
+                        ->defaultNull()
+                        ->info('If true, this variation file will be generated, if missing, when its URL is generated. Overrides the library-level cache.must_store_when_generating_url setting; when null, falls back to it.')
                     ->end()
                     ->append($this->addPixelRatiosNode())
                     ->arrayNode('transformers')
@@ -1468,6 +1474,7 @@ class JoliMediaBundle extends AbstractBundle
                 '$postProcessorsConfiguration' => array_replace_recursive($libraryConfig['post_processors'] ?? [], $variationConfig['post_processors'] ?? []),
                 '$voters' => array_map(service(...), $voterServiceIds),
                 '$multiplier' => $variationConfig['pixel_ratio'],
+                '$mustStoreWhenGeneratingUrl' => $variationConfig['must_store_when_generating_url'] ?? null,
             ])
             ->tag($variationServiceTag, ['name' => $slugger->slug($variationName)->lower()->toString()])
         ;

--- a/src/Model/MediaVariation.php
+++ b/src/Model/MediaVariation.php
@@ -3,6 +3,7 @@
 namespace JoliCode\MediaBundle\Model;
 
 use JoliCode\MediaBundle\Binary\Binary;
+use JoliCode\MediaBundle\Conversion\Converter;
 use JoliCode\MediaBundle\Library\Library;
 use JoliCode\MediaBundle\Storage\CacheStorage;
 use JoliCode\MediaBundle\Variation\Variation;
@@ -10,7 +11,14 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class MediaVariation implements StorableInterface
 {
+    /**
+     * @var (callable(): Converter)|null
+     */
+    public static $converterInitializer;
+
     private ?bool $stored = null;
+
+    private bool $isConvertingForUrlGeneration = false;
 
     public function __construct(
         private readonly Media $media,
@@ -90,6 +98,21 @@ class MediaVariation implements StorableInterface
     public function getUrl(
         int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
     ): string {
+        if (isset(self::$converterInitializer)
+            && !$this->isConvertingForUrlGeneration
+            && $this->getStorage()->mustStoreWhenGeneratingUrl($this)
+        ) {
+            // guard against re-entrance: the conversion pipeline may generate
+            // the URL of the variation being converted (eg. in the profiler)
+            $this->isConvertingForUrlGeneration = true;
+
+            try {
+                (self::$converterInitializer)()->convertIfMustStoreWhenGeneratingUrl($this);
+            } finally {
+                $this->isConvertingForUrlGeneration = false;
+            }
+        }
+
         return $this->getStorage()->getUrl($this->media->getPath(), $this->variation, $referenceType);
     }
 

--- a/src/Storage/CacheStorage.php
+++ b/src/Storage/CacheStorage.php
@@ -221,7 +221,10 @@ class CacheStorage
 
     public function mustStoreWhenGeneratingUrl(MediaVariation $mediaVariation): bool
     {
-        return !$mediaVariation->isStored() && $this->mustStoreWhenGeneratingUrl;
+        $mustStore = $mediaVariation->getVariation()->mustStoreWhenGeneratingUrl()
+            ?? $this->mustStoreWhenGeneratingUrl;
+
+        return $mustStore && !$mediaVariation->isStored();
     }
 
     private function getRouteName(): string

--- a/src/Twig/Components/Img.php
+++ b/src/Twig/Components/Img.php
@@ -2,7 +2,6 @@
 
 namespace JoliCode\MediaBundle\Twig\Components;
 
-use JoliCode\MediaBundle\Conversion\Converter;
 use JoliCode\MediaBundle\Exception\MediaNotFoundException;
 use JoliCode\MediaBundle\Library\LibraryContainer;
 use JoliCode\MediaBundle\Model\Media;
@@ -39,7 +38,6 @@ class Img
     public ?string $sizes = null;
 
     public function __construct(
-        private readonly Converter $converter,
         private readonly Resolver $resolver,
         private readonly LibraryContainer $libraries,
         private readonly ?LoggerInterface $logger = null,
@@ -145,23 +143,12 @@ class Img
 
         $this->media = $media;
 
-        if ($media instanceof MediaVariation) {
-            try {
-                $this->converter->convertIfMustStoreWhenGeneratingUrl($media);
+        if ($media instanceof MediaVariation && $allowAppendWebpAlternativeSource) {
+            // when displaying an img tag in the context of a picture tag, try to get the webp alternative source
+            $webpAlternativeVariation = $media->getVariation()->getWebpAlternativeVariation();
 
-                if ($allowAppendWebpAlternativeSource) {
-                    // when displaying an iimg tag in the ocntext of a picture tag, try to get the webp alternative source
-                    $webpAlternativeVariation = $media->getVariation()->getWebpAlternativeVariation();
-
-                    if ($webpAlternativeVariation instanceof Variation) {
-                        $this->webpAlternativeSource = $webpAlternativeVariation->getName();
-                    }
-                }
-            } catch (\RuntimeException $e) {
-                $this->logger?->warning('Could not generate the variation file', [
-                    'exception' => $e,
-                    'media' => $media,
-                ]);
+            if ($webpAlternativeVariation instanceof Variation) {
+                $this->webpAlternativeSource = $webpAlternativeVariation->getName();
             }
         }
 
@@ -217,14 +204,7 @@ class Img
                     continue;
                 }
 
-                try {
-                    $this->converter->convertMediaVariation($variationMedia, false);
-                } catch (\RuntimeException $e) {
-                    $this->logger?->warning('Could not generate the variation file', [
-                        'exception' => $e,
-                        'media' => $variationMedia,
-                    ]);
-                }
+                $url = $variationMedia->getUrl();
 
                 if (!$variationMedia->isStored()) {
                     continue;
@@ -234,7 +214,7 @@ class Img
                 $dimensions = $binary->getPixelDimensions();
 
                 if (false !== $dimensions) {
-                    $this->srcset[$dimensions['width']] = $variationMedia->getUrl();
+                    $this->srcset[$dimensions['width']] = $url;
                 }
             }
         }

--- a/src/Twig/Components/Source.php
+++ b/src/Twig/Components/Source.php
@@ -2,7 +2,6 @@
 
 namespace JoliCode\MediaBundle\Twig\Components;
 
-use JoliCode\MediaBundle\Conversion\Converter;
 use JoliCode\MediaBundle\Model\Format;
 use JoliCode\MediaBundle\Model\Media;
 use JoliCode\MediaBundle\Model\MediaVariation;
@@ -33,7 +32,6 @@ class Source
     public ?array $webpAlternativeSrcset = [];
 
     public function __construct(
-        private readonly Converter $converter,
         private readonly Resolver $resolver,
         private readonly ?LoggerInterface $logger = null,
     ) {
@@ -58,15 +56,6 @@ class Source
             }
 
             $this->srcset = $mediaVariation->getUrl();
-
-            try {
-                $this->converter->convertIfMustStoreWhenGeneratingUrl($mediaVariation);
-            } catch (\RuntimeException $e) {
-                $this->logger?->warning('Could not generate the variation file', [
-                    'exception' => $e,
-                    'mediaVariation' => $mediaVariation,
-                ]);
-            }
 
             if ($mediaVariation->isStored()) {
                 $this->type = $mediaVariation->getMimeType();
@@ -113,15 +102,7 @@ class Source
                 throw new \InvalidArgumentException(\sprintf('Media variation "%s" not found for the media "%s".', $name, $media->getPath()));
             }
 
-            try {
-                $this->converter->convertIfMustStoreWhenGeneratingUrl($mediaVariation);
-                $candidates[] = trim(\sprintf('%s %s', $mediaVariation->getUrl(), $descriptor));
-            } catch (\RuntimeException $e) {
-                $this->logger?->warning('Could not generate the variation file', [
-                    'exception' => $e,
-                    'mediaVariation' => $mediaVariation,
-                ]);
-            }
+            $candidates[] = trim(\sprintf('%s %s', $mediaVariation->getUrl(), $descriptor));
 
             if (!$skipAutoDimensions && $mediaVariation->isStored()) {
                 $types[] = $mediaVariation->getMimeType();

--- a/src/Twig/JoliMediaExtension.php
+++ b/src/Twig/JoliMediaExtension.php
@@ -2,7 +2,6 @@
 
 namespace JoliCode\MediaBundle\Twig;
 
-use JoliCode\MediaBundle\Conversion\Converter;
 use JoliCode\MediaBundle\Model\Media;
 use JoliCode\MediaBundle\Model\MediaVariation;
 use JoliCode\MediaBundle\Resolver\Resolver;
@@ -14,7 +13,6 @@ class JoliMediaExtension extends AbstractExtension
 {
     public function __construct(
         private readonly Resolver $resolver,
-        private readonly Converter $converter,
     ) {
     }
 
@@ -42,17 +40,7 @@ class JoliMediaExtension extends AbstractExtension
         ?string $libraryName = null,
         int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH,
     ): ?string {
-        $media = $this->getMediaVariation($path, $variationName, $libraryName);
-
-        if ($media instanceof MediaVariation) {
-            try {
-                $this->converter->convertIfMustStoreWhenGeneratingUrl($media);
-            } catch (\Exception) {
-                // ignore errors
-            }
-        }
-
-        return $media?->getUrl($referenceType);
+        return $this->getMediaVariation($path, $variationName, $libraryName)?->getUrl($referenceType);
     }
 
     private function getMediaVariation(

--- a/src/Variation/Variation.php
+++ b/src/Variation/Variation.php
@@ -31,6 +31,7 @@ class Variation
         private readonly array $voters = [],
         private ?self $webpAlternativeVariation = null,
         private readonly float $multiplier = 1.0,
+        private readonly ?bool $mustStoreWhenGeneratingUrl = null,
     ) {
     }
 
@@ -59,6 +60,7 @@ class Variation
             $this->voters,
             $this->webpAlternativeVariation,
             $this->multiplier,
+            $this->mustStoreWhenGeneratingUrl,
         );
     }
 
@@ -99,6 +101,11 @@ class Variation
     public function getMultiplier(): float
     {
         return $this->multiplier;
+    }
+
+    public function mustStoreWhenGeneratingUrl(): ?bool
+    {
+        return $this->mustStoreWhenGeneratingUrl;
     }
 
     public function getName(): string

--- a/src/Variation/Variation.php
+++ b/src/Variation/Variation.php
@@ -58,6 +58,7 @@ class Variation
             $this->postProcessorsConfiguration,
             $this->voters,
             $this->webpAlternativeVariation,
+            $this->multiplier,
         );
     }
 

--- a/tests/src/Application/config/packages/joli_media.php
+++ b/tests/src/Application/config/packages/joli_media.php
@@ -60,6 +60,18 @@ return static function (ContainerConfigurator $container): void {
                             ],
                         ],
                     ],
+                    // overrides the library-level "must_store_when_generating_url" setting
+                    'variation-auto-stored' => [
+                        'must_store_when_generating_url' => true,
+                        'transformers' => [
+                            'resize' => [
+                                'width' => 180,
+                                'height' => 109,
+                                'mode' => 'inside',
+                                'allow_upscale' => false,
+                            ],
+                        ],
+                    ],
                 ],
             ],
 
@@ -81,6 +93,28 @@ return static function (ContainerConfigurator $container): void {
                 'enable_auto_webp' => true,
                 'variations' => [
                     'variation-standard' => [
+                        'transformers' => [
+                            'resize' => [
+                                'width' => 180,
+                                'height' => 109,
+                                'mode' => 'inside',
+                                'allow_upscale' => false,
+                            ],
+                        ],
+                    ],
+                    'variation-large' => [
+                        'transformers' => [
+                            'resize' => [
+                                'width' => 800,
+                                'height' => 600,
+                                'mode' => 'inside',
+                                'allow_upscale' => false,
+                            ],
+                        ],
+                    ],
+                    // overrides the library-level "must_store_when_generating_url" setting
+                    'variation-never-stored' => [
+                        'must_store_when_generating_url' => false,
                         'transformers' => [
                             'resize' => [
                                 'width' => 180,

--- a/tests/src/BaseTestCase.php
+++ b/tests/src/BaseTestCase.php
@@ -246,6 +246,7 @@ class BaseTestCase extends WebTestCase
         Filesystem $filesystem,
         string $urlPath,
         UrlGeneratorInterface $urlGenerator,
+        bool $mustStoreWhenGeneratingUrl = false,
     ): CacheStorage {
         $cache = $this->createMock(CacheInterface::class);
         $cache->method('get')->willReturnCallback(function (string $key, callable $callback) {
@@ -270,7 +271,7 @@ class BaseTestCase extends WebTestCase
             $strategy,
             $filesystem,
             $urlPath,
-            false,
+            $mustStoreWhenGeneratingUrl,
             $urlGenerator,
             $mimeTypeGuesser,
             $mediaVariationPropertyAccessor,

--- a/tests/src/Conversion/ConverterTest.php
+++ b/tests/src/Conversion/ConverterTest.php
@@ -3,6 +3,7 @@
 namespace JoliCode\MediaBundle\Tests\Conversion;
 
 use Imagine\Imagick\Imagine as ImagineImagine;
+use JoliCode\MediaBundle\Binary\Binary;
 use JoliCode\MediaBundle\Conversion\Converter;
 use JoliCode\MediaBundle\Library\Library;
 use JoliCode\MediaBundle\Library\LibraryContainer;
@@ -125,6 +126,52 @@ class ConverterTest extends BaseTestCase
         yield ['webp', 'avif', 7675, 'image/avif'];
     }
 
+    public function testConvertIfMustStoreWhenGeneratingUrlHonorsTheLibrarySetting(): void
+    {
+        // the test library cache storage is configured with must_store_when_generating_url = false
+        $mediaVariation = $this->createMediaVariation('must-store/library.jpeg', 'thumbnail');
+
+        $this->converter->convertIfMustStoreWhenGeneratingUrl($mediaVariation);
+
+        self::assertFalse($mediaVariation->isStored());
+    }
+
+    public function testConvertIfMustStoreWhenGeneratingUrlHonorsTheVariationSetting(): void
+    {
+        // the variation-level setting overrides the library-level one
+        $mediaVariation = $this->createMediaVariation('must-store/variation.jpeg', 'auto-stored-thumbnail');
+
+        $this->converter->convertIfMustStoreWhenGeneratingUrl($mediaVariation);
+
+        self::assertTrue($mediaVariation->isStored());
+    }
+
+    public function testConvertIfMustStoreWhenGeneratingUrlIsANoOpWhenAlreadyStored(): void
+    {
+        $mediaVariation = $this->createMediaVariation('must-store/stored.jpeg', 'auto-stored-thumbnail');
+        $this->converter->convertMediaVariation($mediaVariation);
+        $initialBinary = $mediaVariation->getBinary();
+
+        $this->converter->convertIfMustStoreWhenGeneratingUrl($mediaVariation);
+
+        self::assertSame($initialBinary, $mediaVariation->getBinary());
+    }
+
+    public function testConvertIfMustStoreWhenGeneratingUrlSwallowsConversionErrors(): void
+    {
+        // an empty binary makes the transformation throw an UnprocessableMediaException,
+        // as its pixel dimensions cannot be determined
+        $mediaVariation = $this->createMediaVariation(
+            'must-store/failing.jpeg',
+            'failing-auto-stored-thumbnail',
+            new Binary('image/jpeg', 'jpeg', ''),
+        );
+
+        $this->converter->convertIfMustStoreWhenGeneratingUrl($mediaVariation);
+
+        self::assertFalse($mediaVariation->isStored());
+    }
+
     public function testConvertWithoutTransformersConvertsTheFormat(): void
     {
         // a variation with a target format but no transformers must convert the
@@ -177,7 +224,37 @@ class ConverterTest extends BaseTestCase
             new TransformerChain([]),
         );
 
+        $variations['auto-stored-thumbnail'] = static fn (): Variation => new Variation(
+            'auto-stored-thumbnail',
+            Format::WEBP,
+            new TransformerChain([]),
+            mustStoreWhenGeneratingUrl: true,
+        );
+
+        $variations['failing-auto-stored-thumbnail'] = static fn (): Variation => new Variation(
+            'failing-auto-stored-thumbnail',
+            Format::WEBP,
+            new TransformerChain([
+                new Resize(400, 300),
+            ]),
+            mustStoreWhenGeneratingUrl: true,
+        );
+
         return $variations;
+    }
+
+    private function createMediaVariation(string $filename, string $variationName, ?Binary $binary = null): MediaVariation
+    {
+        $media = new Media($filename, $this->originalStorage);
+        $media->store($binary ?? $this->getFixtureBinary('jpeg'));
+
+        $mediaVariation = $this->converter->getMediaVariation($filename, $variationName, $this->library->getName());
+
+        if (!$mediaVariation instanceof MediaVariation) {
+            self::fail(\sprintf('The media variation "%s" was not created.', $variationName));
+        }
+
+        return $mediaVariation;
     }
 
     private function getVariationName(?string $toExtension): string

--- a/tests/src/DependencyInjection/ConfigurationTest.php
+++ b/tests/src/DependencyInjection/ConfigurationTest.php
@@ -103,6 +103,32 @@ class ConfigurationTest extends TestCase
         $this->assertNull($config['pre_processors']['App\PreProcessor\CustomPreProcessor']['process_timeout']);
     }
 
+    public function testVariationMustStoreWhenGeneratingUrlConfiguration(): void
+    {
+        $config = $this->processConfiguration([
+            [
+                'libraries' => [
+                    'default' => [
+                        'original' => ['flysystem' => 'flysystem.original'],
+                        'cache' => ['flysystem' => 'flysystem.cache'],
+                        'variations' => [
+                            'thumbnail' => [
+                                'must_store_when_generating_url' => true,
+                            ],
+                            'large' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $variations = $config['libraries']['default']['variations'];
+
+        $this->assertTrue($variations['thumbnail']['must_store_when_generating_url']);
+        // when not set, the value is null and falls back to the library-level setting
+        $this->assertNull($variations['large']['must_store_when_generating_url']);
+    }
+
     public function testDefaultTrashPathConfiguration(): void
     {
         // the default value bypasses the normalization, so it must already be normalized

--- a/tests/src/Model/MediaVariationTest.php
+++ b/tests/src/Model/MediaVariationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace JoliCode\MediaBundle\Tests\Model;
+
+use JoliCode\MediaBundle\Conversion\Converter;
+use JoliCode\MediaBundle\Library\Library;
+use JoliCode\MediaBundle\Model\Format;
+use JoliCode\MediaBundle\Model\Media;
+use JoliCode\MediaBundle\Model\MediaVariation;
+use JoliCode\MediaBundle\Tests\BaseTestCase;
+use JoliCode\MediaBundle\Transformer\TransformerChain;
+use JoliCode\MediaBundle\Variation\Variation;
+
+class MediaVariationTest extends BaseTestCase
+{
+    /**
+     * @var (callable(): Converter)|null
+     */
+    private $previousConverterInitializer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->previousConverterInitializer = MediaVariation::$converterInitializer;
+        MediaVariation::$converterInitializer = null;
+    }
+
+    protected function tearDown(): void
+    {
+        MediaVariation::$converterInitializer = $this->previousConverterInitializer;
+
+        parent::tearDown();
+    }
+
+    public function testGetUrlDoesNotConvertWithoutConverterInitializer(): void
+    {
+        $mediaVariation = $this->createStoredMedia($this->createLibrary(true))->createVariation('thumbnail');
+
+        self::assertStringStartsWith('/auto/cache/thumbnail/', $mediaVariation->getUrl());
+        self::assertFalse($mediaVariation->isStored());
+    }
+
+    public function testGetUrlConvertsWhenMustStoreWhenGeneratingUrl(): void
+    {
+        $calls = 0;
+        MediaVariation::$converterInitializer = function () use (&$calls): Converter {
+            ++$calls;
+
+            return $this->converter;
+        };
+
+        $mediaVariation = $this->createStoredMedia($this->createLibrary(true))->createVariation('thumbnail');
+
+        self::assertStringStartsWith('/auto/cache/thumbnail/', $mediaVariation->getUrl());
+        self::assertTrue($mediaVariation->isStored());
+        self::assertSame(1, $calls);
+
+        // a stored variation must not trigger another conversion
+        $mediaVariation->getUrl();
+        self::assertSame(1, $calls);
+    }
+
+    public function testGetUrlDoesNotConvertWhenMustStoreWhenGeneratingUrlIsDisabled(): void
+    {
+        $calls = 0;
+        MediaVariation::$converterInitializer = function () use (&$calls): Converter {
+            ++$calls;
+
+            return $this->converter;
+        };
+
+        $mediaVariation = $this->createStoredMedia($this->createLibrary(false))->createVariation('thumbnail');
+
+        self::assertStringStartsWith('/auto/cache/thumbnail/', $mediaVariation->getUrl());
+        self::assertFalse($mediaVariation->isStored());
+        self::assertSame(0, $calls);
+    }
+
+    public function testGetUrlHonorsTheVariationLevelOverride(): void
+    {
+        MediaVariation::$converterInitializer = fn (): Converter => $this->converter;
+
+        // the variation-level setting enables the conversion in a library where it is disabled
+        $mediaVariation = $this->createStoredMedia($this->createLibrary(false, true))->createVariation('thumbnail');
+        $mediaVariation->getUrl();
+        self::assertTrue($mediaVariation->isStored());
+
+        // the variation-level setting disables the conversion in a library where it is enabled
+        $mediaVariation = $this->createStoredMedia($this->createLibrary(true, false))->createVariation('thumbnail');
+        $mediaVariation->getUrl();
+        self::assertFalse($mediaVariation->isStored());
+    }
+
+    public function testGetUrlGuardsAgainstNestedConversion(): void
+    {
+        $mediaVariation = $this->createStoredMedia($this->createLibrary(true))->createVariation('thumbnail');
+
+        $calls = 0;
+        MediaVariation::$converterInitializer = function () use (&$calls, $mediaVariation): Converter {
+            ++$calls;
+            // simulate a URL generation happening during the conversion, as the
+            // profiler does when it collects the transformation data
+            $mediaVariation->getUrl();
+
+            return $this->converter;
+        };
+
+        $mediaVariation->getUrl();
+
+        self::assertSame(1, $calls);
+        self::assertTrue($mediaVariation->isStored());
+    }
+
+    private function createLibrary(bool $mustStoreWhenGeneratingUrl, ?bool $variationMustStoreWhenGeneratingUrl = null): Library
+    {
+        $urlGenerator = $this->createUrlGenerator([
+            'auto' => [
+                'original' => '/auto/media',
+                'cache' => '/auto/cache',
+            ],
+        ]);
+        $originalStorage = $this->createOriginalStorage('auto', $this->createFilesystem(), '/auto/media', $urlGenerator);
+        $cacheStorage = $this->createCacheStorage('auto', $this->createFilesystem(), '/auto/cache', $urlGenerator, $mustStoreWhenGeneratingUrl);
+        $variation = new Variation(
+            'thumbnail',
+            Format::WEBP,
+            new TransformerChain([]),
+            mustStoreWhenGeneratingUrl: $variationMustStoreWhenGeneratingUrl,
+        );
+
+        return new Library(
+            'auto',
+            $originalStorage,
+            $cacheStorage,
+            $this->createVariationContainer($cacheStorage, [
+                'thumbnail' => static fn (): Variation => $variation,
+            ]),
+        );
+    }
+
+    private function createStoredMedia(Library $library): Media
+    {
+        $media = new Media('test.jpg', $library->getOriginalStorage(), self::getFixtureBinary('jpeg'));
+        $media->store();
+
+        return $media;
+    }
+}

--- a/tests/src/Twig/Component/ImgTest.php
+++ b/tests/src/Twig/Component/ImgTest.php
@@ -55,11 +55,13 @@ class ImgTest extends BaseTestCase
         $binary = new Binary('image/jpeg', Format::JPEG->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::JPEG_FIXTURE_PATH));
         $media = new Media(self::PARTIALLY_STORED_MEDIA, $libraries->getDefault()->getOriginalStorage(), $binary);
         $media->store();
+        $libraries->getDefault()->deleteAllVariations(self::PARTIALLY_STORED_MEDIA);
 
         // store the self::PARTIALLY_STORED_MEDIA media in the "auto_generate" library, but none of its variations
         $binary = new Binary('image/jpeg', Format::JPEG->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::JPEG_FIXTURE_PATH));
         $media = new Media(self::PARTIALLY_STORED_MEDIA, $libraries->get('auto_generate')->getOriginalStorage(), $binary);
         $media->store();
+        $libraries->get('auto_generate')->deleteAllVariations(self::PARTIALLY_STORED_MEDIA);
 
         // store the self::TIFF_MEDIA media
         $binary = new Binary('image/tiff', Format::TIFF->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::TIFF_FIXTURE_PATH));
@@ -72,6 +74,7 @@ class ImgTest extends BaseTestCase
         $binary = new Binary('image/jpeg', Format::JPEG->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::JPEG_FIXTURE_PATH));
         $media = new Media(self::BROKEN_FILENAME, $libraries->getDefault()->getOriginalStorage(), $binary);
         $media->store();
+        $libraries->getDefault()->deleteAllVariations(self::BROKEN_FILENAME);
     }
 
     public static function tearDownAfterClass(): void
@@ -84,6 +87,8 @@ class ImgTest extends BaseTestCase
         $library->getOriginalStorage()->delete(self::COMPLETELY_STORED_MEDIA);
         $library->getOriginalStorage()->delete(self::PARTIALLY_STORED_MEDIA);
         $library->deleteAllVariations(self::PARTIALLY_STORED_MEDIA);
+        $library->getOriginalStorage()->delete(self::BROKEN_FILENAME);
+        $library->deleteAllVariations(self::BROKEN_FILENAME);
 
         $library = $libraries->get('auto_generate');
         $library->getOriginalStorage()->delete(self::PARTIALLY_STORED_MEDIA);
@@ -186,7 +191,21 @@ class ImgTest extends BaseTestCase
                 'variation' => ['variation-standard', 'variation-large', 'variation-extra-large'],
                 'alt' => 'Alternative text',
             ],
-            '<img src="/media/cache/variation-standard/partially-stored-media.jpg" loading="lazy" decoding="async" alt="Alternative text" srcset="/media/cache/variation-standard/partially-stored-media.jpg 145w, /media/cache/variation-large/partially-stored-media.jpg 800w, /media/cache/variation-extra-large/partially-stored-media.jpg 1800w" sizes="145px">',
+            // the srcset variations are not eagerly generated anymore, as the
+            // library does not enable must_store_when_generating_url
+            '<img src="/media/cache/variation-standard/partially-stored-media.jpg" loading="lazy" decoding="async" alt="Alternative text">',
+        ];
+        yield 'auto-generate-partial-media-srcset-multiple' => [
+            Img::class,
+            [
+                'path' => self::PARTIALLY_STORED_MEDIA,
+                'library' => 'auto_generate',
+                'variation' => ['variation-standard', 'variation-large'],
+                'alt' => 'Alternative text',
+            ],
+            // the library enables must_store_when_generating_url, so the srcset
+            // variations are generated when their URL is generated
+            '<img src="/media-auto-generate/cache/variation-standard/partially-stored-media.jpg" loading="lazy" decoding="async" alt="Alternative text" srcset="/media-auto-generate/cache/variation-standard/partially-stored-media.jpg 145w, /media-auto-generate/cache/variation-large/partially-stored-media.jpg 800w" sizes="145px" width="145" height="109">',
         ];
         yield 'existing-media-with-skip-auto-dimensions' => [
             Img::class,
@@ -271,7 +290,9 @@ class ImgTest extends BaseTestCase
                 'path' => self::BROKEN_FILENAME,
                 'variation' => ['variation-standard', 'variation-large', 'variation-extra-large'],
             ],
-            '<img src="/media/cache/variation-standard/some%5C%20filename.jpg" loading="lazy" decoding="async" srcset="/media/cache/variation-standard/some%5C%20filename.jpg 145w, /media/cache/variation-large/some%5C%20filename.jpg 800w, /media/cache/variation-extra-large/some%5C%20filename.jpg 1800w" sizes="145px">',
+            // the srcset variations are not eagerly generated anymore, as the
+            // library does not enable must_store_when_generating_url
+            '<img src="/media/cache/variation-standard/some%5C%20filename.jpg" loading="lazy" decoding="async">',
         ];
         yield 'non-existing-media-variation' => [
             Img::class,

--- a/tests/src/Twig/JoliMediaExtensionTest.php
+++ b/tests/src/Twig/JoliMediaExtensionTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace JoliCode\MediaBundle\Tests\Twig;
+
+use JoliCode\MediaBundle\Binary\Binary;
+use JoliCode\MediaBundle\Library\LibraryContainer;
+use JoliCode\MediaBundle\Model\Format;
+use JoliCode\MediaBundle\Model\Media;
+use JoliCode\MediaBundle\Tests\Application\Kernel;
+use JoliCode\MediaBundle\Tests\BaseTestCase;
+use Twig\Environment;
+
+class JoliMediaExtensionTest extends BaseTestCase
+{
+    private const FILTER_MEDIA = 'joli-media-extension-test.jpg';
+
+    private const DIRECT_MEDIA = 'joli-media-extension-direct-test.jpg';
+
+    public static function setUpBeforeClass(): void
+    {
+        $libraries = self::getLibraryContainer();
+
+        foreach (['default', 'auto_generate'] as $libraryName) {
+            $library = $libraries->get($libraryName);
+
+            foreach ([self::FILTER_MEDIA, self::DIRECT_MEDIA] as $path) {
+                $binary = new Binary('image/jpeg', Format::JPEG->value, BaseTestCase::getFixtureBinaryContent(BaseTestCase::JPEG_FIXTURE_PATH));
+                $media = new Media($path, $library->getOriginalStorage(), $binary);
+                $media->store();
+
+                // remove variation files possibly left over by a previous run
+                $library->deleteAllVariations($path);
+            }
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $libraries = self::getLibraryContainer();
+
+        foreach (['default', 'auto_generate'] as $libraryName) {
+            $library = $libraries->get($libraryName);
+
+            foreach ([self::FILTER_MEDIA, self::DIRECT_MEDIA] as $path) {
+                $library->getOriginalStorage()->delete($path);
+                $library->deleteAllVariations($path);
+            }
+        }
+    }
+
+    public function testTheFilterStoresTheVariationWhenTheLibraryRequiresIt(): void
+    {
+        $url = $this->renderUrlFilter(self::FILTER_MEDIA, 'variation-standard', 'auto_generate');
+
+        self::assertSame('/media-auto-generate/cache/variation-standard/' . self::FILTER_MEDIA, $url);
+        self::assertTrue($this->isVariationStored('auto_generate', self::FILTER_MEDIA, 'variation-standard'));
+    }
+
+    public function testTheFilterDoesNotStoreTheVariationWhenTheLibraryDoesNotRequireIt(): void
+    {
+        $url = $this->renderUrlFilter(self::FILTER_MEDIA, 'variation-standard', 'default');
+
+        self::assertSame('/media/cache/variation-standard/' . self::FILTER_MEDIA, $url);
+        self::assertFalse($this->isVariationStored('default', self::FILTER_MEDIA, 'variation-standard'));
+    }
+
+    public function testTheFilterHonorsTheVariationLevelSetting(): void
+    {
+        // the "variation-auto-stored" variation enables the storage in the
+        // "default" library, where it is disabled at the library level
+        $this->renderUrlFilter(self::FILTER_MEDIA, 'variation-auto-stored', 'default');
+
+        self::assertTrue($this->isVariationStored('default', self::FILTER_MEDIA, 'variation-auto-stored'));
+
+        // the "variation-never-stored" variation disables the storage in the
+        // "auto_generate" library, where it is enabled at the library level
+        $this->renderUrlFilter(self::FILTER_MEDIA, 'variation-never-stored', 'auto_generate');
+
+        self::assertFalse($this->isVariationStored('auto_generate', self::FILTER_MEDIA, 'variation-never-stored'));
+    }
+
+    public function testGeneratingTheUrlFromTheModelStoresTheVariation(): void
+    {
+        // the conversion is triggered by MediaVariation::getUrl() itself, without
+        // any Twig involvement - eg. from an API Platform normalizer
+        $library = self::getLibraryContainer()->get('auto_generate');
+        $media = new Media(self::DIRECT_MEDIA, $library->getOriginalStorage());
+
+        $url = $media->createVariation('variation-standard')->getUrl();
+
+        self::assertSame('/media-auto-generate/cache/variation-standard/' . self::DIRECT_MEDIA, $url);
+        self::assertTrue($this->isVariationStored('auto_generate', self::DIRECT_MEDIA, 'variation-standard'));
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    private static function getLibraryContainer(): LibraryContainer
+    {
+        /** @var LibraryContainer $libraries */
+        $libraries = static::getContainer()->get('joli_media.library_container');
+
+        return $libraries;
+    }
+
+    private function renderUrlFilter(string $path, string $variation, string $library): string
+    {
+        /** @var Environment $twig */
+        $twig = static::getContainer()->get('twig');
+
+        return $twig
+            ->createTemplate(\sprintf("{{ path|joli_media_url('%s', '%s') }}", $variation, $library))
+            ->render(['path' => $path])
+        ;
+    }
+
+    private function isVariationStored(string $libraryName, string $path, string $variationName): bool
+    {
+        $library = self::getLibraryContainer()->get($libraryName);
+
+        return $library->getCacheStorage()->has($path, $library->getVariation($variationName));
+    }
+}

--- a/tests/src/Variation/VariationTest.php
+++ b/tests/src/Variation/VariationTest.php
@@ -144,6 +144,22 @@ class VariationTest extends BaseTestCase
         self::assertSame($this->preProcessor, $clonedVariation->getPreProcessors()->current());
     }
 
+    public function testCloneWithOutputFormatPreservesMultiplierAndMustStoreWhenGeneratingUrl(): void
+    {
+        $variation = new Variation(
+            'test_variation',
+            Format::JPEG,
+            $this->transformerChain,
+            multiplier: 2.0,
+            mustStoreWhenGeneratingUrl: true,
+        );
+
+        $clonedVariation = $variation->cloneWithOutputFormat(Format::PNG);
+
+        self::assertSame(2.0, $clonedVariation->getMultiplier());
+        self::assertTrue($clonedVariation->mustStoreWhenGeneratingUrl());
+    }
+
     public function testWebpAlternativeVariation(): void
     {
         $webpVariation = new Variation(


### PR DESCRIPTION
fix #80

This moves the `must_store_when_generating_url` handling from the Twig layer into `MediaVariation::getUrl()` itself, so that every URL generation (Twig components and filters, admin bridges, or custom code such as an API Platform normalizer) generates and stores the missing variation file when the setting is enabled.

The setting `must_store_when_generating_url` can also now be overridden per variation, with a fallback on the library-level cache configuration.