### PR TITLE
EasyAdmin bridge: use the generic `fa` icon class instead of fas/far/fa-solid/fa-regular

### DIFF
--- a/src/Bridge/EasyAdmin/templates/_as_image.html.twig
+++ b/src/Bridge/EasyAdmin/templates/_as_image.html.twig
@@ -9,14 +9,14 @@
     />
 {%- else -%}
     {%- if media.filetype == 'pdf' -%}
-        <i class="fa-solid fa-file-pdf" title="{{ 'media.type.pdf'|trans }}"></i>
+        <i class="fa fa-file-pdf" title="{{ 'media.type.pdf'|trans }}"></i>
     {%- elseif media.filetype == 'video' %}
-        <i class="fa-solid fa-file-video" title="{{ 'media.type.video'|trans }}"></i>
+        <i class="fa fa-file-video" title="{{ 'media.type.video'|trans }}"></i>
     {%- elseif media.filetype == 'audio' %}
-        <i class="fa-solid fa-file-audio" title="{{ 'media.type.audio'|trans }}"></i>
+        <i class="fa fa-file-audio" title="{{ 'media.type.audio'|trans }}"></i>
     {%- elseif media.filetype == 'text' %}
-        <i class="fa-solid fa-file-lines" title="{{ 'media.type.text'|trans }}"></i>
+        <i class="fa fa-file-lines" title="{{ 'media.type.text'|trans }}"></i>
     {%- else %}
-        <i class="fa-solid fa-file" title="{{ 'media.type.file'|trans }}"></i>
+        <i class="fa fa-file" title="{{ 'media.type.file'|trans }}"></i>
     {%- endif -%}
 {%- endif -%}

--- a/src/Bridge/EasyAdmin/templates/choose.html.twig
+++ b/src/Bridge/EasyAdmin/templates/choose.html.twig
@@ -10,7 +10,7 @@
         <twig:ea:Button
             htmlElement="a"
             variant="primary"
-            icon="fas fa-plus-circle"
+            icon="fa fa-plus-circle"
             data-component="media-add"
             tabindex="0"
         >{{ 'media.add'|trans(domain: 'JoliMediaEasyAdminBundle') }}</twig:ea:Button>

--- a/src/Bridge/EasyAdmin/templates/explore.html.twig
+++ b/src/Bridge/EasyAdmin/templates/explore.html.twig
@@ -59,7 +59,7 @@
     <twig:ea:Button
         htmlElement="a"
         variant="primary"
-        icon="fas fa-plus-circle"
+        icon="fa fa-plus-circle"
         data-component="media-add"
         tabindex="0"
     >{{ 'media.add'|trans(domain: 'JoliMediaEasyAdminBundle') }}</twig:ea:Button>

--- a/src/Bridge/EasyAdmin/templates/form/form_theme.html.twig
+++ b/src/Bridge/EasyAdmin/templates/form/form_theme.html.twig
@@ -17,7 +17,7 @@
                     htmlElement="a"
                     variant="link"
                     size="sm"
-                    icon="fas fa-plus"
+                    icon="fa fa-plus"
                     href="{{ joli_media_admin_url('choose', { key: '__FOLDER__' }) }}"
                     data-component="media-choice-edit"
                     data-folder="{{ folder }}"
@@ -27,7 +27,7 @@
                 <twig:ea:Button
                     variant="link"
                     size="sm"
-                    icon="fas fa-minus-circle"
+                    icon="fa fa-minus-circle"
                     class="ms-2 text-danger hide-when-empty"
                     data-component="media-choice-delete"
                 >{{ 'action.remove'|trans(domain: 'JoliMediaEasyAdminBundle') }}</twig:ea:Button>

--- a/src/Bridge/EasyAdmin/templates/list.html.twig
+++ b/src/Bridge/EasyAdmin/templates/list.html.twig
@@ -33,7 +33,7 @@
                         <tr>
                             <td data-column="name" data-label="name" class="text-left" dir="ltr">
                                 <a href="{{ joli_media_admin_url(action, '.' != parent_key ? { key: parent_key } : { }) }}" class="gallery-list-item gallery-list-item--back">
-                                    <span class="gallery-list-item__icon"><i class="fas fa-arrow-left"></i></span>
+                                    <span class="gallery-list-item__icon"><i class="fa fa-arrow-left"></i></span>
                                     {{ 'back'|trans }}
                                 </a>
                             </td>
@@ -90,7 +90,7 @@
                 {% if parent_key != '' and current_key != '.' -%}
                     <li class="gallery-grid-item gallery-grid-item--back">
                         <a href="{{ joli_media_admin_url(action, '.' != parent_key ? { key: parent_key } : { }) }}" class="gallery-grid-item__link">
-                            <span class="gallery-grid-item__icon"><i class="fas fa-arrow-left"></i></span>
+                            <span class="gallery-grid-item__icon"><i class="fa fa-arrow-left"></i></span>
                             <span class="gallery-grid-item__name">{{ 'back'|trans }}</span>
                         </a>
                     </li>
@@ -100,7 +100,7 @@
                     {% if joli_media_admin_is_granted('LIST', path: directory) %}
                         <li class="gallery-grid-item">
                             <a href="{{ joli_media_admin_url(action, { key: directory }) }}" class="gallery-grid-item__link">
-                                <span class="gallery-grid-item__icon"><i class="fas fa-folder"></i></span>
+                                <span class="gallery-grid-item__icon"><i class="fa fa-folder"></i></span>
                                 <span class="gallery-grid-item__name">{{ directory|joli_media_admin_basename }}</span>
                             </a>
                         </li>
@@ -133,7 +133,7 @@
                         <twig:ea:Button
                             htmlElement="a"
                             size="sm"
-                            icon="fas fa-list"
+                            icon="fa fa-list"
                             href="{{ joli_media_admin_url(action, { key: current_key }, { view_mode: 'list' }) }}"
                             class="{{ 'list' == current_view_mode ? 'active disabled' }}"
                             aria-current="{{ 'list' == current_view_mode ? 'true' : 'false' }}"
@@ -141,7 +141,7 @@
                         <twig:ea:Button
                             htmlElement="a"
                             size="sm"
-                            icon="fas fa-th-large"
+                            icon="fa fa-th-large"
                             href="{{ joli_media_admin_url(action, { key: current_key }, { view_mode: 'grid' }) }}"
                             class="{{ 'grid' == current_view_mode ? 'active disabled' }}"
                             aria-current="{{ 'grid' == current_view_mode ? 'true' : 'false' }}"
@@ -158,7 +158,7 @@
                                 {% if joli_media_admin_is_granted('CREATE_DIRECTORY', path: current_key) %}
                                     <twig:ea:Button
                                         htmlElement="a"
-                                        icon="fa-solid fa-folder-plus"
+                                        icon="fa fa-folder-plus"
                                         class="me-sm-2"
                                         data-component="folder-create"
                                         tabindex="0"
@@ -169,7 +169,7 @@
                                 {% if base_template ends with '/choose.html.twig' %}
                                     <twig:ea:Button
                                         htmlElement="a"
-                                        icon="fa-solid fa-magnifying-glass"
+                                        icon="fa fa-magnifying-glass"
                                         class="me-sm-2"
                                         data-component="search"
                                         tabindex="0"

--- a/src/Bridge/EasyAdmin/templates/show.html.twig
+++ b/src/Bridge/EasyAdmin/templates/show.html.twig
@@ -146,7 +146,7 @@
                 <li class="nav-item" role="presentation">
                     <a class="nav-link{% if displayed_tab == 1 %} active{% endif %}" href="#tab-general" id="tablist-tab-general" data-bs-toggle="tab" aria-selected="true" role="tab">
                         <span class="icon tab-nav-item-icon">
-                            <i class="fas fa-circle-info"></i>
+                            <i class="fa fa-circle-info"></i>
                         </span>
                         {{ 'general'|trans }}
                     </a>
@@ -154,7 +154,7 @@
                 <li class="nav-item" role="presentation">
                     <a class="nav-link{% if displayed_tab == 2 %} active{% endif %}" href="#tab-variations" id="tablist-tab-variations" data-bs-toggle="tab" aria-selected="false" tabindex="-1" role="tab">
                         <span class="icon tab-nav-item-icon">
-                            <i class="fas fa-images"></i>
+                            <i class="fa fa-images"></i>
                         </span>
                         {{ 'variation.label_plural'|trans }}
                     </a>
@@ -224,7 +224,7 @@
                                                 <twig:ea:Button
                                                     htmlElement="a"
                                                     size="sm"
-                                                    icon="fa-regular fa-clone"
+                                                    icon="fa fa-clone"
                                                     href="{{ variation.url }}"
                                                     class="clipboard-btn"
                                                     data-clipboard-target="#media-{{ variation.variation.name }}-url"
@@ -234,7 +234,7 @@
                                                     <twig:ea:Button
                                                         htmlElement="a"
                                                         size="sm"
-                                                        icon="fa-solid fa-arrows-rotate"
+                                                        icon="fa fa-arrows-rotate"
                                                         href="{{ joli_media_admin_url('regenerateVariation', { key: media.path, variation: variation.variation.name }) }}"
                                                     >{{ 'action.regenerate'|trans(domain: 'JoliMediaEasyAdminBundle') }}</twig:ea:Button>
                                                 {% endif %}
@@ -273,7 +273,7 @@
                             type="button"
                             variant="primary"
                             size="sm"
-                            icon="fa-regular fa-clone"
+                            icon="fa fa-clone"
                             class="clipboard-btn"
                             data-clipboard-target="#media-url"
                         >{{ 'action.copy'|trans(domain: 'JoliMediaEasyAdminBundle') }}</twig:ea:Button>
@@ -290,7 +290,7 @@
                                 type="button"
                                 variant="primary"
                                 size="sm"
-                                icon="fa-regular fa-clone"
+                                icon="fa fa-clone"
                                 class="clipboard-btn"
                                 data-clipboard-target="#media-markdown-code"
                             >{{ 'action.copy'|trans(domain: 'JoliMediaEasyAdminBundle') }}</twig:ea:Button>
@@ -308,7 +308,7 @@
                                 type="button"
                                 variant="primary"
                                 size="sm"
-                                icon="fa-regular fa-clone"
+                                icon="fa fa-clone"
                                 class="clipboard-btn"
                                 data-clipboard-target="#media-html-code"
                             >{{ 'action.copy'|trans(domain: 'JoliMediaEasyAdminBundle') }}</twig:ea:Button>

--- a/src/Bridge/EasyAdmin/templates/uploaded_file_preview.html.twig
+++ b/src/Bridge/EasyAdmin/templates/uploaded_file_preview.html.twig
@@ -3,10 +3,10 @@
   <div class="uploader-preview-details">
     <div class="uploader-preview-name gallery-grid-item__name">
       <span class="uploader-success-marker">
-        <i class="fa-solid fa-circle-check"></i>
+        <i class="fa fa-circle-check"></i>
       </span>
       <span class="uploader-error-marker">
-        <i class="fa-solid fa-circle-exclamation"></i>
+        <i class="fa fa-circle-exclamation"></i>
       </span>
       <span data-upload-name></span>
     </div>


### PR DESCRIPTION
## What

Replace the 25 `fas fa-*`, `far fa-*`, `fa-solid fa-*` and `fa-regular fa-*` occurrences in the EasyAdmin bridge templates with the plain `fa fa-*` class, which most icons of the bridge already use.

## Why

Each of those aliases selects a Font Awesome *style* (solid, regular) on its own. A host application that decided on a single style for its whole admin — and therefore only loads that style's font — gets blank icons in the media library, while the page still renders with a 200: with Font Awesome 7, `fas` and `far` map to the "classic" family in weight 900/400, i.e. to font files the host may not ship.

The plain `fa` class leaves the style decision to the host stylesheet, which is where it belongs. With the default Font Awesome setup nothing changes visually: `fa` resolves to the solid style.

## Scope

EasyAdmin bridge templates only (`src/Bridge/EasyAdmin/templates/**`). The Sonata and Sylius bridges were left untouched; happy to align them too if you prefer.